### PR TITLE
PolarSSL v1.1 support

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -44,12 +44,16 @@
 
 #ifdef USE_POLARSSL
 #include <polarssl/havege.h>
+#if defined POLARSSL_API_V1 && !defined(POLARSSL_API_V1_0)
+#define RAND_bytes(_dst_, _size_) havege_random(&hs, _dst_, _size_)
+#else
 #define RAND_bytes(_dst_, _size_) do { \
 	int i; \
 	for (i = 0; i < _size_; i++) { \
 	_dst_[i] = havege_rand(&hs); \
 	} \
  } while (0);
+#endif
 
 extern havege_state hs;
 #endif

--- a/src/crypt.h
+++ b/src/crypt.h
@@ -38,6 +38,19 @@
 #ifdef USE_POLARSSL
 #include <polarssl/havege.h>
 #include <polarssl/aes.h>
+#include <polarssl/version.h>
+#ifndef POLARSSL_VERSION_MAJOR
+	#define POLARSSL_API_V0
+#else
+#if (POLARSSL_VERSION_MAJOR == 0)
+	#define POLARSSL_API_V0
+#else
+#define POLARSSL_API_V1
+#if (POLARSSL_VERSION_MINOR == 0)
+	#define POLARSSL_API_V1_0
+#endif
+#endif
+#endif
 #define AES_BLOCK_SIZE 16
 #else
 #include <openssl/rand.h>

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -187,7 +187,11 @@ SSL_handle_t *SSLi_newconnection(int *fd, bool_t *SSLready)
 	ssl_set_endpoint(ssl, SSL_IS_SERVER);	
 	ssl_set_authmode(ssl, SSL_VERIFY_NONE);
 
+#if defined POLARSSL_API_V1 && !defined(POLARSSL_API_V1_0)
+	ssl_set_rng(ssl, havege_random, &hs);
+#else
 	ssl_set_rng(ssl, havege_rand, &hs);
+#endif
 	ssl_set_dbg(ssl, pssl_debug, NULL);
 	ssl_set_bio(ssl, net_recv, fd, net_send, fd);
 

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -46,7 +46,10 @@
 #if (POLARSSL_VERSION_MAJOR == 0)
 	#define POLARSSL_API_V0
 #else
-	#define POLARSSL_API_V1
+#define POLARSSL_API_V1
+#if (POLARSSL_VERSION_MINOR == 0)
+	#define POLARSSL_API_V1_0
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Fixes issue #5

You should drop support for old PolarSSL API versions in further releases because it really is a mess in the code ATM with PolarSSL v0, v1 and v1.1 distincts APIs. Maybe same thing for OpenSSL 0.9.8 and 1.0.0?

This code should also work for any other 1.x releases of PolarSSL if the API doesn't change :)
