### PR TITLE
make note of autogen script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Instructions for building from source
 	* [libprotoc-c](http://code.google.com/p/protobuf-c/) version 0.14 or 0.15 (use --disable-protoc option in its ./configure to build only the library). If you for some reason have to run an earlier version you need to recompile the protocol file `Mumble.proto` using the protobuf compiler for the corresponding version.
 
 2. Build
+	* `./autogen.sh`
 	* `./configure`
 	* `make`
 


### PR DESCRIPTION
I tend to update umurmur once every 8 months or so, whenever I rebuild my server. Every time I go by the readme, and fail to remember to use the provided autogen.sh script. I thought maybe adding this would be helpful to me in the future.
