### PR TITLE
Changed to monotonic clock for timespan measurements

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -36,12 +36,12 @@
 
 static uint64_t Timer_now()
 {
-	struct timeval tv;
+	struct timespec ts;
 	uint64_t e;
 	
-	gettimeofday(&tv, NULL);
-	e = tv.tv_sec * 1000000LL;
-	e += tv.tv_usec;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        e = ts.tv_sec * 1000000LL;
+        e += ts.tv_nsec / 1000LL; //convert to microseconds
 	return e;
 }
 


### PR DESCRIPTION
Fix for https://github.com/fatbob313/umurmur/issues/20
Uses monotonic clock instead of gettimeofday() which can provide wrong time if system clock changes (eg.due to NTP time sync, manual time change).
After this fix timespan measurements will be always stable and accurate.
