### PR TITLE
Add client indication of silent channels

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -315,19 +315,23 @@ int Chan_userJoin_id(int channelid, client_t *client)
 
 channelJoinResult_t Chan_userJoin_id_test(int channelid, client_t *client)
 {
+	channelJoinResult_t result;
 	channel_t *ch_itr = NULL;
 	do {
 		Chan_iterate(&ch_itr);
 	} while (ch_itr != NULL && ch_itr->id != channelid);
 	if (ch_itr == NULL) {
 		Log_warn("Channel id %d not found - ignoring.", channelid);
-		return CHJOIN_NOTFOUND;
+		result.CHJOIN_NOTFOUND = true;
 	}
-	else if (ch_itr->noenter)
-		return CHJOIN_NOENTER;
-	else if (ch_itr->password && !Client_token_match(client, ch_itr->password))
-		return CHJOIN_WRONGPW;
-	else return CHJOIN_OK;
+	else
+		result.CHJOIN_NOTFOUND = false;
+
+	result.CHJOIN_NOENTER = ch_itr->noenter;
+	result.CHJOIN_WRONGPW = ch_itr->password && !Client_token_match(client, ch_itr->password) && !client->isAdmin;
+	result.CHJOIN_SILENT = ch_itr->silent;
+
+	return result;
 }
 
 #if 0

--- a/src/channel.h
+++ b/src/channel.h
@@ -57,11 +57,11 @@ typedef struct {
 	struct dlist node;
 } channellist_t;
 
-typedef enum {
-	CHJOIN_OK,
+typedef struct {
+  bool_t CHJOIN_SILENT,
 	CHJOIN_NOENTER,
 	CHJOIN_WRONGPW,
-	CHJOIN_NOTFOUND,
+	CHJOIN_NOTFOUND;
 } channelJoinResult_t;
 	
 void Chan_init();

--- a/src/client.h
+++ b/src/client.h
@@ -91,6 +91,7 @@ typedef struct {
 	int tokencount;
 	uint8_t hash[20];
 	bool_t isAdmin;
+	bool_t isSuppressed;
 	float UDPPingAvg, UDPPingVar, TCPPingAvg, TCPPingVar;
 	uint32_t UDPPackets, TCPPackets;
 } client_t;

--- a/src/messagehandler.c
+++ b/src/messagehandler.c
@@ -303,6 +303,11 @@ void Mh_handle_message(client_t *client, message_t *msg)
 		sendmsg->payload.userState->has_channel_id = true;
 		sendmsg->payload.userState->channel_id = ((channel_t *)client->channel)->id;
 
+		if (defaultChan->silent) {
+			sendmsg->payload.userState->has_suppress = true;
+			sendmsg->payload.userState->suppress = true;
+		}
+
 		Client_send_message_except(client, sendmsg);
 
 		client_itr = NULL;
@@ -315,6 +320,10 @@ void Mh_handle_message(client_t *client, message_t *msg)
 			sendmsg->payload.userState->name = strdup(client_itr->username);
 			sendmsg->payload.userState->has_channel_id = true;
 			sendmsg->payload.userState->channel_id = ((channel_t *)client_itr->channel)->id;
+			sendmsg->payload.userState->has_suppress = ((channel_t *)client_itr->channel)->silent;
+			sendmsg->payload.userState->suppress = ((channel_t *)client_itr->channel)->silent;
+
+			client_itr->isSuppressed = ((channel_t *)client_itr->channel)->silent;
 
 			if (client_itr->self_deaf) {
 				sendmsg->payload.userState->has_self_deaf = true;
@@ -504,29 +513,43 @@ void Mh_handle_message(client_t *client, message_t *msg)
 		}
 		if (msg->payload.userState->has_channel_id) {
 			int leave_id;
-			channelJoinResult_t chjoin_rc = Chan_userJoin_id_test(msg->payload.userState->channel_id, target);
-			
-			if (chjoin_rc != CHJOIN_OK) {
-				if (chjoin_rc == CHJOIN_WRONGPW) {
-					if (target == client && !client->isAdmin) {
-						sendPermissionDenied(client, "Wrong channel password");
-						break;
-					}
-					/* Tricky one: if user hasn't the password, but is moved to the channel by admin then let
-					 * the user in. Also let admin user in regardless of channel password.
-					 * Take no action on other errors.
-					 */
-					else if (!client->isAdmin)
-						break;
+
+			channelJoinResult_t result = Chan_userJoin_id_test(msg->payload.userState->channel_id, target);
+
+			if (result.CHJOIN_NOENTER || result.CHJOIN_NOTFOUND)
+				break;
+
+			if (result.CHJOIN_WRONGPW) {
+				if (target == client && !client->isAdmin) {
+					sendPermissionDenied(client, "Wrong channel password");
+					break;
 				}
-				else break;
+				/* Tricky one: if user hasn't the password, but is moved to the channel by admin then let
+				 * the user in. Also let admin user in regardless of channel password.
+				 * Take no action on other errors.
+				 */
+				else if (!client->isAdmin)
+					break;
 			}
-			
+
 			leave_id = Chan_userJoin_id(msg->payload.userState->channel_id, target);
 			if (leave_id > 0) {
 				Log_debug("Removing channel ID %d", leave_id);
 				sendmsg = Msg_create(ChannelRemove);
 				sendmsg->payload.channelRemove->channel_id = leave_id;
+			}
+
+			if (result.CHJOIN_SILENT) {
+				if (!target->isSuppressed) {
+				msg->payload.userState->has_suppress = true;
+				msg->payload.userState->suppress = true;
+				target->isSuppressed = true;
+				}
+			}
+			else if (target->isSuppressed) {
+				msg->payload.userState->has_suppress = true;
+				msg->payload.userState->suppress = false;
+				target->isSuppressed = false;
 			}
 		}
 		if (msg->payload.userState->has_plugin_context) {
@@ -746,8 +769,15 @@ void Mh_handle_message(client_t *client, message_t *msg)
 		sendmsg->payload.userState->session = client->sessionId;
 		sendmsg->payload.userState->has_channel_id = true;
 		sendmsg->payload.userState->channel_id = newchan->id;
+
+		if (client->isSuppressed) {
+			sendmsg->payload.userState->has_suppress = true;
+			sendmsg->payload.userState->suppress = false;
+			client->isSuppressed = false;
+		}
+
 		Client_send_message_except(NULL, sendmsg);
-		
+
 		leave_id = Chan_userJoin(newchan, client);
 		if (leave_id > 0) {
 			Log_debug("Removing channel ID %d", leave_id);


### PR DESCRIPTION
This will set users in silent channel green mute-icon indicating being suppressed like original murmur server would do on silent channels.
## 

Sorry for making a copy of my previous pull request, there was some problem with my fork so I started over, hopefully works better this time.
