### PR TITLE
workaround for missing clock_gettime() in OS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_INIT([umurmur], [0.2.14], [http://code.google.com/p/umurmur/issues/entry], [u
 AC_CONFIG_SRCDIR([src/client.h])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE
+AC_CANONICAL_HOST
 
 # Configure options.
 AC_ARG_WITH([ssl], [AC_HELP_STRING([--with-ssl=@<:@LIB@:>@], [SSL library (openssl|polarssl) @<:@default=polarssl@:>@])], [], [with_ssl=polarssl])
@@ -48,7 +49,14 @@ AC_CHECK_HEADERS([google/protobuf-c/protobuf-c.h], [], [AC_MSG_ERROR([could not 
 AC_CHECK_LIB([protobuf-c], [protobuf_c_data_buffer_init], [], [AC_MSG_ERROR([could not find protobuf-c library])])
 AC_CHECK_HEADERS([libconfig.h], [], [AC_MSG_ERROR([could not find libconfig.h])])
 AC_CHECK_LIB([config], [config_init], [], [AC_MSG_ERROR([could not find libconfig])])
-AC_CHECK_FUNC([clock_gettime], [], [AC_CHECK_LIB([rt], [clock_gettime], [], [AC_MSG_ERROR([could not find clock_gettime() in librt])])])
+case $host_os in
+  darwin* )
+    AC_CHECK_FUNC([clock_get_time], [], [AC_MSG_ERROR([could not find clock_get_time()])])
+    ;;
+  * )
+    AC_CHECK_FUNC([clock_gettime], [], [AC_CHECK_LIB([rt], [clock_gettime], [], [AC_MSG_ERROR([could not find clock_gettime() in librt])])])
+    ;;
+esac
 AS_IF([test "x$with_ssl" = xpolarssl], [
 	AC_CHECK_HEADERS([polarssl/ssl.h], [], [AC_MSG_ERROR([could not find polarssl/ssl.h])])
 	AC_CHECK_HEADERS([polarssl/version.h], [], [AC_MSG_ERROR([could not find polarssl/version.h])])

--- a/src/timer.c
+++ b/src/timer.c
@@ -32,16 +32,31 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 #include "timer.h"
 
 static uint64_t Timer_now()
 {
 	struct timespec ts;
 	uint64_t e;
-	
-        clock_gettime(CLOCK_MONOTONIC, &ts);
-        e = ts.tv_sec * 1000000LL;
-        e += ts.tv_nsec / 1000LL; //convert to microseconds
+
+#ifdef __MACH__
+  clock_serv_t clock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &clock);
+  clock_get_time(clock, &mts);
+  mach_port_deallocate(mach_task_self(), clock);
+  ts.tv_sec = mts.tv_sec;
+  ts.tv_nsec = mts.tv_nsec;
+#else
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
+  e = ts.tv_sec * 1000000LL;
+  e += ts.tv_nsec / 1000LL; //convert to microseconds
 	return e;
 }
 


### PR DESCRIPTION
This commit allow compilation under OS X

see gist #1087739 by Juan Batiz-Benet(jbenet)
