### PR TITLE
Libcap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,8 @@ AS_IF([test "x$with_ssl" = xopenssl], [
 	AC_CHECK_LIB([ssl], [SSL_library_init], [], [AC_MSG_ERROR([could not find libssl])])
 ])
 
+LIBCAP_NG_PATH
+
 # Checks for header files.
 AC_FUNC_ALLOCA
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h limits.h netinet/tcp.h stddef.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h sys/poll.h], [], [AC_MSG_ERROR([missing a required header])])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,4 +28,4 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 bin_PROGRAMS=umurmurd
 umurmurd_SOURCES=client.c main.c messages.c pds.c server.c ssl.c log.c conf.c crypt.c timer.c messagehandler.c channel.c Mumble.pb-c.c voicetarget.c ban.c
-
+umurmurd_LDADD=$(CAPNG_LDADD)


### PR DESCRIPTION
This patch adds optional support for libcap-ng for privilege dropping. This allows uMurmur to keep the sys_nice capability, allowing it to change the scheduler after dropping privileges. This fixes issue #7.
