### PR TITLE
Fixes for issue #52

### DIFF
--- a/src/ban.c
+++ b/src/ban.c
@@ -90,8 +90,12 @@ void Ban_UserBan(client_t *client, char *reason)
 
 	SSLi_hash2hex(ban->hash, hexhash);
 
+	char *clientAddressString = Util_clientAddressToString(client);
+
 	Log_info_client(client, "User kickbanned. Reason: '%s' Hash: %s IP: %s Banned for: %d seconds",
-		ban->reason, hexhash, Util_clientAddressToString(client), ban->duration);
+		ban->reason, hexhash, clientAddressString, ban->duration);
+
+	free(clientAddressString);
 }
 
 

--- a/src/ban.c
+++ b/src/ban.c
@@ -107,9 +107,10 @@ void Ban_pruneBanned()
 	list_iterate(itr, &banlist) {
 		ban = list_get_entry(itr, ban_t, node);
 #ifdef DEBUG
+		char hexhash[41];
 		SSLi_hash2hex(ban->hash, hexhash);
 		Log_debug("BL: User %s Reason: '%s' Hash: %s IP: %s Time left: %d",
-			ban->name, ban->reason, hexhash, Util_addressToString(&ban->address)),
+			ban->name, ban->reason, hexhash, Util_addressToString(&ban->address),
 			ban->time + ban->duration - time(NULL));
 #endif
 		/* Duration of 0 = forever */

--- a/src/ban.c
+++ b/src/ban.c
@@ -109,9 +109,11 @@ void Ban_pruneBanned()
 #ifdef DEBUG
 		char hexhash[41];
 		SSLi_hash2hex(ban->hash, hexhash);
+		char *addressString = Util_addressToString(&ban->address);
 		Log_debug("BL: User %s Reason: '%s' Hash: %s IP: %s Time left: %d",
-			ban->name, ban->reason, hexhash, Util_addressToString(&ban->address),
+			ban->name, ban->reason, hexhash, addressString,
 			ban->time + ban->duration - time(NULL));
+		free(addressString);
 #endif
 		/* Duration of 0 = forever */
 		if (ban->duration != 0 && ban->time + ban->duration - time(NULL) <= 0) {
@@ -307,7 +309,9 @@ static void Ban_saveBanFile(void)
 		ban = list_get_entry(itr, ban_t, node);
 		SSLi_hash2hex(ban->hash, hexhash);
 
-		fprintf(file, "%s,%s,%d,%ld,%d,%s,%s\n", hexhash, Util_addressToString(&ban->address),ban->mask, (long int)ban->time, ban->duration, ban->name, ban->reason);
+		char *addressString = Util_addressToString(&ban->address);
+		fprintf(file, "%s,%s,%d,%ld,%d,%s,%s\n", hexhash, addressString,ban->mask, (long int)ban->time, ban->duration, ban->name, ban->reason);
+		free(addressString);
 	}
 	fclose(file);
 	banlist_changed = false;

--- a/src/client.c
+++ b/src/client.c
@@ -834,7 +834,9 @@ int Client_read_udp(int udpsock)
 			if (memcmp(itraddress, fromaddress, addresslength) == 0) {
 				if (checkDecrypt(itr, encrypted, buffer, len)) {
 					memcpy(itr->key, key, KEY_LENGTH);
-					Log_info_client(itr, "New UDP connection from %s on port %d", Util_clientAddressToString(itr), fromport);
+					char* clientAddressString = Util_clientAddressToString(itr);
+					Log_info_client(itr, "New UDP connection from %s on port %d", clientAddressString, fromport);
+					free(clientAddressString);
 					memcpy(&itr->remote_udp, &from, sizeof(struct sockaddr_storage));
 					break;
 				}
@@ -848,6 +850,9 @@ int Client_read_udp(int udpsock)
 	itr->bUDP = true;
 	len -= 4; /* Adjust for crypt header */
 	msgType = (UDPMessageType_t)((buffer[0] >> 5) & 0x7);
+
+	char *clientAddressString = NULL;
+
 	switch (msgType) {
 		case UDPVoiceSpeex:
 		case UDPVoiceCELTAlpha:
@@ -862,7 +867,9 @@ int Client_read_udp(int udpsock)
 			Client_send_udp(itr, buffer, len);
 			break;
 		default:
-			Log_debug("Unknown UDP message type from %s port %d", Util_clientAddressToString(itr), fromport);
+			clientAddressString = Util_clientAddressToString(itr);
+			Log_debug("Unknown UDP message type from %s port %d", clientAddressString, fromport);
+			free(clientAddressString);
 			break;
 	}
 

--- a/src/client.c
+++ b/src/client.c
@@ -323,9 +323,12 @@ int Client_add(int fd, struct sockaddr_storage *remote)
 {
 	client_t* newclient;
 	message_t *sendmsg;
+	char* addressString = NULL;
 
 	if (Ban_isBannedAddr(remote)) {
-		Log_info("Address %s banned. Disconnecting", Util_addressToString(remote));
+		addressString = Util_addressToString(remote);
+		Log_info("Address %s banned. Disconnecting", addressString);
+		free(addressString);
 		return -1;
 	}
 
@@ -336,7 +339,9 @@ int Client_add(int fd, struct sockaddr_storage *remote)
 	memcpy(&newclient->remote_tcp, remote, sizeof(struct sockaddr_storage));
 	newclient->ssl = SSLi_newconnection(&newclient->tcpfd, &newclient->SSLready);
 	if (newclient->ssl == NULL) {
-		Log_warn("SSL negotiation failed with %s on port %d", Util_addressToString(remote), Util_addressToPort(remote));
+		addressString = Util_addressToString(remote);
+		Log_warn("SSL negotiation failed with %s on port %d", addressString, Util_addressToPort(remote));
+		free(addressString);
 		free(newclient);
 		return -1;
 	}

--- a/src/log.c
+++ b/src/log.c
@@ -191,11 +191,13 @@ void Log_info_client(client_t *client, const char *logstring, ...)
 	offset += vsnprintf(&buf[offset], STRSIZE - offset, logstring, argp);
 	va_end(argp);
 
+	char *clientAddressString = Util_clientAddressToString(client);
 	offset += snprintf(&buf[offset], STRSIZE - offset, " - [%d] %s@%s:%d",
 		client->sessionId,
 		client->username == NULL ? "" : client->username,
-		Util_clientAddressToString(client),
+		clientAddressString,
 		Util_clientAddressToPortTCP(client));
+	free(clientAddressString);
 
 	if (termprint)
 		fprintf(stderr, "%s\n", buf);

--- a/src/ssli_polarssl.c
+++ b/src/ssli_polarssl.c
@@ -265,12 +265,10 @@ SSL_handle_t *SSLi_newconnection(int *fd, bool_t *SSLready)
 	ssl_session *ssn;
 	int rc;
 
-	ssl = malloc(sizeof(ssl_context));
-	ssn = malloc(sizeof(ssl_session));
+	ssl = calloc(1, sizeof(ssl_context));
+	ssn = calloc(1, sizeof(ssl_session));
 	if (!ssl || !ssn)
 		Log_fatal("Out of memory");
-	memset(ssl, 0, sizeof(ssl_context));
-	memset(ssn, 0, sizeof(ssl_session));
 
 	rc = ssl_init(ssl);
 	if (rc != 0 )


### PR DESCRIPTION
This patchset closes some memory leaks when using the address-to-string conversion utility functions. I still get "Instruments" saying there is a leak in SSLi_newConnection(...) when using polarSSL, but i can't seem to find it.