### PR TITLE
A little bit of warning related cleanup

### DIFF
--- a/src/crypt.h
+++ b/src/crypt.h
@@ -42,7 +42,7 @@
 #define CRYPT_AES_KEY aes_context
 #define AES_BLOCK_SIZE 16
 
-#define CRYPT_RANDOM_BYTES(dest, size) RAND_bytes((dest), (size))
+#define CRYPT_RANDOM_BYTES(dest, size) RAND_bytes((unsigned char *)(dest), (size))
 #define CRYPT_SET_ENC_KEY(dest, source, size) aes_setkey_enc((dest), (source), (size));
 #define CRYPT_SET_DEC_KEY(dest, source, size) aes_setkey_dec((dest), (source), (size));
 
@@ -69,7 +69,7 @@
 #include <openssl/aes.h>
 
 #define CRYPT_AES_KEY AES_KEY
-#define CRYPT_RANDOM_BYTES(dest, size) RAND_bytes((dest), (size))
+#define CRYPT_RANDOM_BYTES(dest, size) RAND_bytes((unsigned char *)(dest), (size))
 #define CRYPT_SET_ENC_KEY(dest, source, size) AES_set_encrypt_key((source), (size), (dest));
 #define CRYPT_SET_DEC_KEY(dest, source, size) AES_set_decrypt_key((source), (size), (dest));
 

--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -235,7 +235,7 @@ static void SSL_initializeCert() {
 
 void SSLi_init(void)
 {
-	const SSL_METHOD *method;
+	SSL_METHOD *method;
 	SSL *ssl;
 	int i, offset = 0, cipherstringlen = 0;
 	STACK_OF(SSL_CIPHER) *cipherlist = NULL, *cipherlist_new = NULL;
@@ -254,7 +254,7 @@ void SSLi_init(void)
 		abort();
 	}
 
-	char* sslCAPath = getStrConf(CAPATH);
+	char const * sslCAPath = getStrConf(CAPATH);
 	if(sslCAPath != NULL)
 	{
 		SSL_CTX_load_verify_locations(context, NULL, sslCAPath);


### PR DESCRIPTION
These two commits fix a couple of warnings in crypt.c and ssli_openssl.c