### PR TITLE
Added socket errno EPROTONOSUPPORT to socket support check in checkIPversions()

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -67,13 +67,13 @@ void checkIPversions()
 	int testsocket = -1;
 
 	testsocket = socket(PF_INET, SOCK_STREAM, 0);
-	hasv4 = (errno == EAFNOSUPPORT) ? false : true;
+	hasv4 = (errno == EAFNOSUPPORT || errno == EPROTONOSUPPORT) ? false : true;
 	if (!(testsocket < 0)) close(testsocket);
 
 	testsocket = socket(PF_INET6, SOCK_STREAM, 0);
-	hasv6 = (errno == EAFNOSUPPORT) ? false : true;
+	hasv6 = (errno == EAFNOSUPPORT || errno == EPROTONOSUPPORT) ? false : true;
 	if (!(testsocket < 0)) close(testsocket);
-
+	
 	if(!hasv4)
 	{
 		Log_info("IPv4 is not supported by this system");
@@ -85,7 +85,6 @@ void checkIPversions()
 		Log_info("IPv6 is not supported by this system");
 		nofServerSocks -= 2;
 	}
-
 	if(nofServerSocks == 0)
 	{
 		Log_fatal("Neither IPv4 nor IPv6 are supported by this system");


### PR DESCRIPTION
The previous check of only EAFNOSUPPORT was failing to detect lack of ipv6 support in my FreeBSD jail system. 