### PR TITLE
Add client Key hash to shm_area

### DIFF
--- a/src/sharedmemory.c
+++ b/src/sharedmemory.c
@@ -77,6 +77,8 @@ void Sharedmemory_update(void)
 				strncpy( shmptr->client[cc].release, client_itr->release, 120 );
 				strncpy( shmptr->client[cc].os_version, client_itr->os_version, 120 );
 
+        strncpy( shmptr->client[cc].hash, client_itr->hash, 20 );
+        
 				shmptr->client[cc].tcp_port = Util_clientAddressToPortTCP( client_itr );
 				shmptr->client[cc].udp_port = Util_clientAddressToPortUDP( client_itr );
 
@@ -98,6 +100,8 @@ void Sharedmemory_update(void)
 				shmptr->client[cc].UDPPingVar = client_itr->UDPPingVar;
 				shmptr->client[cc].TCPPingAvg = client_itr->TCPPingAvg;
 				shmptr->client[cc].TCPPingVar = client_itr->TCPPingVar;
+
+				
 
 				shmptr->client[cc].isAdmin = client_itr->isAdmin;
 				shmptr->client[cc].isSuppressed = client_itr->isSuppressed;

--- a/src/sharedmemory_struct.h
+++ b/src/sharedmemory_struct.h
@@ -4,7 +4,6 @@
 
 typedef struct
 {
-
   char username[121];
   char ipaddress[INET6_ADDRSTRLEN];
   char channel[121];
@@ -13,12 +12,13 @@ typedef struct
   bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording, bOpus;
   int availableBandwidth;
   uint32_t online_secs, idle_secs;
+  uint8_t hash[20];
   bool_t isAdmin;
   bool_t isSuppressed;
   float UDPPingAvg, UDPPingVar, TCPPingAvg, TCPPingVar;
   uint32_t UDPPackets, TCPPackets;
 
-} shmclient_t;
+}shmclient_t;
 
 typedef struct
 {
@@ -29,4 +29,4 @@ typedef struct
   uint8_t alive;
   shmclient_t client[];
 
-} shm_t;
+}shm_t;


### PR DESCRIPTION
I am useing this in my version of to know a user has connected is really that user and not someone just named the same....

This could be used to highlight a user in numurmon a different color if the user is in a your hash file that it would read at startup.. A long way from here thought. I need to finish/polish numurmon up before this.

Main reason for this is to get my code and git the same so I don't have to keep 2 versions around.

This is a hash of the public key right? so I don't think this is a security hole 