### PR TITLE
Do user switch after SSL keys are initialized

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -322,13 +322,6 @@ int main(int argc, char **argv)
 			Log_init(false);
 			if (pidfile != NULL)
 				lockfile(pidfile);
-
-			switch_user();
-
-			/* Reopen log file. If user switch results in access denied, we catch
-			 * it early.
-			 */
-			Log_reset();
 		}
 		else Log_init(true);
 
@@ -364,6 +357,12 @@ int main(int argc, char **argv)
 		if (realtime)
 			setscheduler();
 #endif
+
+		switch_user();
+		/* Reopen log file. If user switch results in access denied, we catch
+		 * it early.
+		 */
+		Log_reset();
 
 		Server_run();
 


### PR DESCRIPTION
From commit message:

```
Since SSL private keys are usually stored as readable by root only, and
if a user to switch to is specified, the switch will already have taken
place before the SSL keys are read. This means that umurmur still won't
have permission to read the keys. The fix is to switch users after
initialization.

The second problem occurs when systemd is used. If systemd is used, it's
better to let systemd handle the daemonizing of the process. However,
this means that the process will never switch users when the systemd
service is started. So this fixes that by switching the user in all
cases.
```

I am not entirely sure what initial thought behind switching the user early in the initialization process was, so I'm not entirely sure if this breaks something. I tested it on my own server and it seems to work without problems.
