### PR TITLE
Fix size of value passed to setsockopt

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -209,7 +209,7 @@ void Server_runLoop(struct pollfd* pollfds)
 
 void Server_setupTCPSockets(struct sockaddr_storage* addresses[2], struct pollfd* pollfds)
 {
-	uint8_t yes = 1;
+	int yes = 1;
 	int sockets[2];
 
 	if (hasv4) {


### PR DESCRIPTION
Passing a `uint8_t` to setsockopt with an optlen of `sizeof (int)` results in stack garbage being present in the higher bits.  Platforms which are picky about optval (SunOS, for example) will toss EINVAL in the face of such inputs.