### PR TITLE
Add show-addresses option, to optionally hide user's IP addresses

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -320,6 +320,13 @@ bool_t getBoolConf(param_t param)
 			else
 				return config_setting_get_bool(setting);
 			break;
+		case SHOW_ADDRESSES:
+			setting = config_lookup(&configuration, "show_addresses");
+			if (!setting)
+				return true;
+			else
+				return config_setting_get_bool(setting);
+			break;
 		default:
 			doAssert(false);
 	}

--- a/src/conf.h
+++ b/src/conf.h
@@ -57,6 +57,7 @@ typedef enum param {
 	BANFILE,
 	SYNC_BANFILE,
 	OPUS_THRESHOLD,
+	SHOW_ADDRESSES,
 } param_t;
 
 typedef struct {

--- a/src/messagehandler.c
+++ b/src/messagehandler.c
@@ -870,17 +870,21 @@ void Mh_handle_message(client_t *client, message_t *msg)
 			sendmsg->payload.userStats->opus = target->bOpus;
 
 			/* Address */
-			sendmsg->payload.userStats->has_address = true;
-			sendmsg->payload.userStats->address.data
-				= Memory_safeMalloc(16, sizeof(uint8_t));
-			memset(sendmsg->payload.userStats->address.data, 0, 16);
-			/* ipv4 representation as ipv6 address. Supposedly correct. */
-			memset(&sendmsg->payload.userStats->address.data[10], 0xff, 2); /* IPv4 */
-      if(target->remote_tcp.ss_family == AF_INET)
-        memcpy(&sendmsg->payload.userStats->address.data[12], &((struct sockaddr_in*)&target->remote_tcp)->sin_addr, 4);
-      else
-        memcpy(&sendmsg->payload.userStats->address.data[0], &((struct sockaddr_in6*)&target->remote_tcp)->sin6_addr, 16);
-			sendmsg->payload.userStats->address.len = 16;
+			if (getBoolConf(SHOW_ADDRESSES)) {
+				sendmsg->payload.userStats->has_address = true;
+				sendmsg->payload.userStats->address.data
+					= Memory_safeMalloc(16, sizeof(uint8_t));
+				memset(sendmsg->payload.userStats->address.data, 0, 16);
+				/* ipv4 representation as ipv6 address. Supposedly correct. */
+				memset(&sendmsg->payload.userStats->address.data[10], 0xff, 2); /* IPv4 */
+				if(target->remote_tcp.ss_family == AF_INET)
+					memcpy(&sendmsg->payload.userStats->address.data[12], &((struct sockaddr_in*)&target->remote_tcp)->sin_addr, 4);
+				else
+					memcpy(&sendmsg->payload.userStats->address.data[0], &((struct sockaddr_in6*)&target->remote_tcp)->sin6_addr, 16);
+				sendmsg->payload.userStats->address.len = 16;
+			} else {
+				sendmsg->payload.userStats->has_address = false;
+			}
 		}
 		/* BW */
 		sendmsg->payload.userStats->has_bandwidth = true;

--- a/umurmur.conf.example
+++ b/umurmur.conf.example
@@ -10,6 +10,7 @@ password = "";
 # sync_banfile = false;      # Keep banfile synced. Default is false, which means it is saved to at shutdown only.
 # allow_textmessage = true;  # Default is true
 # opus_threshold = 100;      # Percentage of users supporting Opus codec for it to be chosen. Default is 100.
+# show_addresses = true;     # Whether to show client's IP addresses under user information
 max_users = 10;
 
 # bindport = 64738;


### PR DESCRIPTION
Currently IP addresses of every connected user are visible to everybody
through the user information dialog. This adds an option of whether or
not to show them, if set to true (default) then everything will be as
before, whereas with false they will not be shown to anybody.

IP addresses will still be logged in log messages and so forth.

Fixes #81.