### PR TITLE
bindport6 defaults to bindport, rather than 64738

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -252,7 +252,10 @@ int getIntConf(param_t param)
 		case BINDPORT6:
 			setting = config_lookup(&configuration, "bindport6");
 			if (!setting)
-				return DEFAULT_BINDPORT;
+				/* If bindport6 is not specified, we default
+				 * to whatever bindport is, rather than always
+				 * default to 64738 */
+				return getIntConf(BINDPORT);
 			else {
 				return config_setting_get_int(setting);
 			}


### PR DESCRIPTION
Previously if bindport6 was unspecified it would always default to
64738, this changes it so that it instead defaults to whatever bindport
is, i.e. as long as bindport6 is unspecified, then umurmur will bind to
the same ports on v4 and v6. If bindport6 is specified it will of course
take precedence.

Suggested in #97.