### PR TITLE
Set stricter compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "The type of build product that should be produced." FORCE)
 endif()
 
-set(CMAKE_C_FLAGS "-std=gnu99 -Wall -Wextra -Werror")
+set(CMAKE_C_FLAGS "-std=gnu99 -Wall -Wextra")
 add_definitions("-D_XOPEN_SOURCE -D_GNU_SOURCE")
 
 include(SelectTLSBackend)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "The type of build product that should be produced." FORCE)
 endif()
 
+set(CMAKE_C_FLAGS "-std=gnu99 -Wall -Wextra -Werror")
+add_definitions("-D_XOPEN_SOURCE -D_GNU_SOURCE")
+
 include(SelectTLSBackend)
 include(SelectRTBackend)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@
 #  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 #  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-AM_CFLAGS=-std=gnu99 -Wall -Wextra -Werror -D_XOPEN_SOURCE -D_GNU_SOURCE
+AM_CFLAGS=-std=gnu99 -Wall -Wextra -Wno-unknown-warning-option -Wno-old-style-declaration -Wno-unused-result -Werror -D_XOPEN_SOURCE -D_GNU_SOURCE
 
 bin_PROGRAMS=umurmurd
 umurmurd_SOURCES=client.c main.c messages.c pds.c server.c log.c conf.c crypt.c timer.c messagehandler.c channel.c Mumble.pb-c.c voicetarget.c ban.c util.c memory.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@
 #  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 #  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-AM_CFLAGS=-std=gnu99 -Wall -Wextra -Wno-unknown-warning-option -Wno-old-style-declaration -Wno-unused-result -Werror -D_XOPEN_SOURCE -D_GNU_SOURCE
+AM_CFLAGS=-std=gnu99 -Wall -Wextra -D_XOPEN_SOURCE -D_GNU_SOURCE
 
 bin_PROGRAMS=umurmurd
 umurmurd_SOURCES=client.c main.c messages.c pds.c server.c log.c conf.c crypt.c timer.c messagehandler.c channel.c Mumble.pb-c.c voicetarget.c ban.c util.c memory.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,8 @@
 #  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 #  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+AM_CFLAGS=-std=gnu99 -Wall -Wextra -Werror -D_XOPEN_SOURCE -D_GNU_SOURCE
+
 bin_PROGRAMS=umurmurd
 umurmurd_SOURCES=client.c main.c messages.c pds.c server.c log.c conf.c crypt.c timer.c messagehandler.c channel.c Mumble.pb-c.c voicetarget.c ban.c util.c memory.c
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -61,11 +61,11 @@ static channel_t *createChannel(int id, const char *name, const char *desc)
 	return ch;
 }
 
-static int findFreeId()
+static uint32_t findFreeId()
 {
-	uint32_t id = 0;
-	channel_t *ch_itr = NULL;
-	for (id = 0; id < UINT_MAX; id++) {
+	uint32_t id;
+	channel_t *ch_itr;
+	for (id = 0; id < UINT32_MAX; id++) {
 		ch_itr = NULL;
 		while ((ch_itr = Chan_iterate(&ch_itr)) != NULL) {
 			if (ch_itr->id == id)
@@ -74,7 +74,7 @@ static int findFreeId()
 		if (ch_itr == NULL) /* Found free id */
 			return id;
 	}
-	return -1;
+	return UINT32_MAX;
 }
 
 #if 0
@@ -255,8 +255,8 @@ void Chan_free()
 
 channel_t *Chan_createChannel(const char *name, const char *desc)
 {
-	int id = findFreeId();
-	if (id < 0)
+	uint32_t id = findFreeId();
+	if (id == UINT32_MAX)
 		Log_fatal("No free channel ID found");
 	return createChannel(id, name, desc);
 }
@@ -279,7 +279,7 @@ void Chan_addChannel(channel_t *parent, channel_t *ch)
 int Chan_userLeave(client_t *client)
 {
 	channel_t *leaving = NULL;
-	int leaving_id = -1;
+	int leaving_id = UINT32_MAX;
 
 	if (client->channel) {
 		list_del(&client->chan_node);
@@ -316,7 +316,7 @@ int Chan_userJoin_id(uint32_t channelid, client_t *client)
 	} while (ch_itr != NULL && ch_itr->id != channelid);
 	if (ch_itr == NULL) {
 		Log_warn("Channel id %d not found - ignoring.", channelid);
-		return -1;
+		return UINT32_MAX;
 	}
 	else
 		return Chan_userJoin(ch_itr, client);

--- a/src/channel.c
+++ b/src/channel.c
@@ -63,7 +63,7 @@ static channel_t *createChannel(int id, const char *name, const char *desc)
 
 static int findFreeId()
 {
-	int id = 0;
+	uint32_t id = 0;
 	channel_t *ch_itr = NULL;
 	for (id = 0; id < INT_MAX; id++) {
 		ch_itr = NULL;
@@ -308,7 +308,7 @@ int Chan_userJoin(channel_t *ch, client_t *client)
 	return leaving_id;
 }
 
-int Chan_userJoin_id(int channelid, client_t *client)
+int Chan_userJoin_id(uint32_t channelid, client_t *client)
 {
 	channel_t *ch_itr = NULL;
 	do {
@@ -322,7 +322,7 @@ int Chan_userJoin_id(int channelid, client_t *client)
 		return Chan_userJoin(ch_itr, client);
 }
 
-channelJoinResult_t Chan_userJoin_id_test(int channelid, client_t *client)
+channelJoinResult_t Chan_userJoin_id_test(uint32_t channelid, client_t *client)
 {
 	channelJoinResult_t result;
 	channel_t *ch_itr = NULL;
@@ -357,7 +357,7 @@ void Chan_addChannel_id(int parentId, channel_t *ch)
 }
 #endif
 
-channel_t *Chan_fromId(int channelid)
+channel_t *Chan_fromId(uint32_t channelid)
 {
 	channel_t *ch_itr = NULL;
 	do {

--- a/src/channel.c
+++ b/src/channel.c
@@ -65,7 +65,7 @@ static int findFreeId()
 {
 	uint32_t id = 0;
 	channel_t *ch_itr = NULL;
-	for (id = 0; id < INT_MAX; id++) {
+	for (id = 0; id < UINT_MAX; id++) {
 		ch_itr = NULL;
 		while ((ch_itr = Chan_iterate(&ch_itr)) != NULL) {
 			if (ch_itr->id == id)

--- a/src/channel.h
+++ b/src/channel.h
@@ -36,7 +36,7 @@
 #include "client.h"
 
 typedef struct channel {
-	int id;
+	uint32_t id;
 	char *name;
 	char *desc;
 	char *password;
@@ -62,7 +62,7 @@ typedef struct {
 	CHJOIN_WRONGPW,
 	CHJOIN_NOTFOUND;
 } channelJoinResult_t;
-	
+
 void Chan_init();
 void Chan_free();
 void Chan_addChannel(channel_t *parent, channel_t *sub);
@@ -70,13 +70,13 @@ void Chan_removeChannel(channel_t *c);
 void Chan_addClient(channel_t *c, client_t *client);
 void Chan_removeClient(channel_t *c, client_t *client);
 int Chan_userJoin(channel_t *ch, client_t *client);
-int Chan_userJoin_id(int channelid, client_t *client);
+int Chan_userJoin_id(uint32_t channelid, client_t *client);
 int Chan_userLeave(client_t *client);
-channelJoinResult_t Chan_userJoin_id_test(int channelid, client_t *client);
+channelJoinResult_t Chan_userJoin_id_test(uint32_t channelid, client_t *client);
 channel_t *Chan_iterate(channel_t **channelpptr);
 channel_t *Chan_iterate_siblings(channel_t *parent, channel_t **channelpptr);
 channel_t *Chan_createChannel(const char *name, const char *desc);
-channel_t *Chan_fromId(int channelid);
+channel_t *Chan_fromId(uint32_t channelid);
 void Chan_freeChannel(channel_t *ch);
 void Chan_buildTreeList(channel_t *ch, struct dlist *head);
 void Chan_freeTreeList(struct dlist *head);

--- a/src/client.c
+++ b/src/client.c
@@ -303,7 +303,7 @@ static int findFreeSessionId()
 	uint32_t id;
 	client_t *itr = NULL;
 
-	for (id = 1; id < INT_MAX; id++) {
+	for (id = 1; id < UINT_MAX; id++) {
 		itr = NULL;
 		while ((itr = Client_iterate(&itr)) != NULL) {
 			if (itr->sessionId == id)

--- a/src/client.c
+++ b/src/client.c
@@ -200,7 +200,8 @@ void Client_token_free(client_t *client)
 void recheckCodecVersions(client_t *connectingClient)
 {
 	client_t *client_itr = NULL;
-	int max = 0, version, current_version;
+	int max = 0;
+	uint32_t version = 0, current_version;
 	int users = 0, opus = 0;
 	message_t *sendmsg;
 	struct dlist codec_list, *itr, *save;
@@ -299,7 +300,7 @@ void recheckCodecVersions(client_t *connectingClient)
 
 static int findFreeSessionId()
 {
-	int id;
+	uint32_t id;
 	client_t *itr = NULL;
 
 	for (id = 1; id < INT_MAX; id++) {
@@ -344,7 +345,7 @@ int Client_add(int fd, struct sockaddr_storage *remote)
 	Timer_init(&newclient->connectTime);
 	Timer_init(&newclient->idleTime);
 	newclient->sessionId = findFreeSessionId();
-	if (newclient->sessionId < 0)
+	if (newclient->sessionId == (uint32_t)-1)
 		Log_fatal("Could not find a free session ID");
 
 	init_list_entry(&newclient->txMsgQueue);
@@ -991,8 +992,8 @@ int Client_voiceMsg(client_t *client, uint8_t *data, int len)
 			}
 		}
 		/* Sessions */
-		for (i = 0; i < TARGET_MAX_SESSIONS && vt->sessions[i] != -1; i++) {
-			client_t *c;
+		for (i = 0; i < TARGET_MAX_SESSIONS && vt->sessions[i] != (uint32_t)-1; i++) {
+			client_t *c = NULL;
 			buffer[0] = (uint8_t) (type | 2);
 			Log_debug("Whisper session %d", vt->sessions[i]);
 			while (Client_iterate(&c) != NULL) {

--- a/src/client.h
+++ b/src/client.h
@@ -70,7 +70,7 @@ typedef struct {
 	struct sockaddr_storage remote_udp;
 	uint8_t rxbuf[BUFSIZE], txbuf[BUFSIZE];
 	uint32_t rxcount, msgsize, drainleft, txcount, txsize;
-	int sessionId;
+	uint32_t sessionId;
 	uint8_t key[KEY_LENGTH];
 	char *username;
 	bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording, bOpus;

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -210,14 +210,14 @@ bool_t CryptState_decrypt(cryptState_t *cs, const unsigned char *source, unsigne
 	return true;
 }
 
-static void inline XOR(subblock *dst, const subblock *a, const subblock *b) {
+static inline void XOR(subblock *dst, const subblock *a, const subblock *b) {
 	int i;
 	for (i=0;i<BLOCKSIZE;i++) {
 		dst[i] = a[i] ^ b[i];
 	}
 }
 
-static void inline S2(subblock *block) {
+static inline void S2(subblock *block) {
 	subblock carry = SWAPPED(block[0]) >> SHIFTBITS;
 	int i;
 	for (i=0;i<BLOCKSIZE-1;i++)
@@ -225,7 +225,7 @@ static void inline S2(subblock *block) {
 	block[BLOCKSIZE-1] = SWAPPED((SWAPPED(block[BLOCKSIZE-1]) << 1) ^(carry * 0x87));
 }
 
-static void inline S3(subblock *block) {
+static inline void S3(subblock *block) {
 	subblock carry = SWAPPED(block[0]) >> SHIFTBITS;
 	int i;
 	for (i=0;i<BLOCKSIZE-1;i++)
@@ -233,7 +233,7 @@ static void inline S3(subblock *block) {
 	block[BLOCKSIZE-1] ^= SWAPPED((SWAPPED(block[BLOCKSIZE-1]) << 1) ^(carry * 0x87));
 }
 
-static void inline ZERO(subblock *block) {
+static inline void ZERO(subblock *block) {
 	int i;
 	for (i=0;i<BLOCKSIZE;i++)
 		block[i]=0;

--- a/src/messagehandler.c
+++ b/src/messagehandler.c
@@ -77,7 +77,7 @@ static void sendPermissionDenied(client_t *client, const char *reason)
 
 static void addTokens(client_t *client, message_t *msg)
 {
-	int i;
+	size_t i;
 	if (client->tokencount + msg->payload.authenticate->n_tokens < MAX_TOKENS) {
 		/* Check lengths first */
 		for (i = 0; i < msg->payload.authenticate->n_tokens; i++) {
@@ -585,7 +585,7 @@ void Mh_handle_message(client_t *client, message_t *msg)
 		}
 
 		if (msg->payload.textMessage->n_channel_id > 0) { /* To channel */
-			int i;
+			uint32_t i;
 			channel_t *ch_itr;
 			for (i = 0; i < msg->payload.textMessage->n_channel_id; i++) {
 				ch_itr = NULL;
@@ -607,7 +607,7 @@ void Mh_handle_message(client_t *client, message_t *msg)
 			} /* for */
 		}
 		if (msg->payload.textMessage->n_session > 0) { /* To user */
-			int i;
+			uint32_t i;
 			client_t *itr;
 			for (i = 0; i < msg->payload.textMessage->n_session; i++) {
 				itr = NULL;
@@ -631,7 +631,8 @@ void Mh_handle_message(client_t *client, message_t *msg)
 
 	case VoiceTarget:
 	{
-		int i, j, count, targetId = msg->payload.voiceTarget->id;
+		size_t i, count;
+		uint32_t j, targetId = msg->payload.voiceTarget->id;
 		struct _MumbleProto__VoiceTarget__Target *target;
 
 		if (!targetId || targetId >= 0x1f)

--- a/src/messagehandler.c
+++ b/src/messagehandler.c
@@ -513,7 +513,7 @@ void Mh_handle_message(client_t *client, message_t *msg)
 			sendmsg = NULL;
 		}
 		if (msg->payload.userState->has_channel_id) {
-			int leave_id;
+			uint32_t leave_id;
 
 			channelJoinResult_t result = Chan_userJoin_id_test(msg->payload.userState->channel_id, target);
 
@@ -534,7 +534,7 @@ void Mh_handle_message(client_t *client, message_t *msg)
 			}
 
 			leave_id = Chan_userJoin_id(msg->payload.userState->channel_id, target);
-			if (leave_id > 0) {
+			if (leave_id > 0 && leave_id != UINT32_MAX) {
 				Log_debug("Removing channel ID %d", leave_id);
 				sendmsg = Msg_create(ChannelRemove);
 				sendmsg->payload.channelRemove->channel_id = leave_id;
@@ -701,7 +701,7 @@ void Mh_handle_message(client_t *client, message_t *msg)
 	case ChannelState:
 	{
 		channel_t *ch_itr, *parent, *newchan;
-		int leave_id;
+		uint32_t leave_id;
 		/* Don't allow any changes to existing channels */
 		if (msg->payload.channelState->has_channel_id) {
 			sendPermissionDenied(client, "Not supported by uMurmur");
@@ -779,7 +779,7 @@ void Mh_handle_message(client_t *client, message_t *msg)
 		Client_send_message_except(NULL, sendmsg);
 
 		leave_id = Chan_userJoin(newchan, client);
-		if (leave_id > 0) {
+		if (leave_id > 0 && leave_id != UINT32_MAX) {
 			Log_debug("Removing channel ID %d", leave_id);
 			sendmsg = Msg_create(ChannelRemove);
 			sendmsg->payload.channelRemove->channel_id = leave_id;

--- a/src/messages.c
+++ b/src/messages.c
@@ -69,7 +69,7 @@ static void Msg_getPreamble(uint8_t *buffer, int *type, int *len)
 #define MAX_MSGSIZE (BUFSIZE - PREAMBLE_SIZE)
 int Msg_messageToNetwork(message_t *msg, uint8_t *buffer)
 {
-	int len;
+	int len = 0;
 	uint8_t *bufptr = buffer + PREAMBLE_SIZE;
 
 	Log_debug("To net: msg type %d", msg->messageType);
@@ -279,7 +279,6 @@ static message_t *Msg_create_nopayload(messageType_t messageType)
 message_t *Msg_create(messageType_t messageType)
 {
 	message_t *msg = Msg_create_nopayload(messageType);
-	int i;
 
 	switch (messageType) {
 	case Version:
@@ -444,7 +443,7 @@ void Msg_inc_ref(message_t *msg)
 
 void Msg_free(message_t *msg)
 {
-	int i;
+	size_t i;
 
 	if (msg->refcount) msg->refcount--;
 	if (msg->refcount > 0)
@@ -674,6 +673,7 @@ message_t *Msg_networkToMessage(uint8_t *data, int size)
 	message_t *msg = NULL;
 	uint8_t *msgData = &data[6];
 	int messageType, msgLen;
+	(void)size; /* TODO: ugly hack to silence compiler. WHY do we not use size? */
 
 	Msg_getPreamble(data, &messageType, &msgLen);
 

--- a/src/pds.c
+++ b/src/pds.c
@@ -55,7 +55,7 @@ static inline void append_val(pds_t *pds, uint64_t val)
 
 void Pds_append_data(pds_t *pds, const uint8_t *data, uint32_t len)
 {
-	int left;
+	uint32_t left;
 	Pds_add_numval(pds, len);
 	left = pds->maxsize - pds->offset;
 	if (left >= len) {
@@ -71,7 +71,7 @@ void Pds_append_data(pds_t *pds, const uint8_t *data, uint32_t len)
 
 void Pds_append_data_nosize(pds_t *pds, const uint8_t *data, uint32_t len)
 {
-	int left;
+	uint32_t left;
 	left = pds->maxsize - pds->offset;
 	if (left >= len) {
 		memcpy(&pds->data[pds->offset], data, len);

--- a/src/ssli_gnutls.c
+++ b/src/ssli_gnutls.c
@@ -35,7 +35,6 @@
 
 #include <stdlib.h>
 
-static gnutls_dh_params_t dhParameters;
 static gnutls_certificate_credentials_t certificate;
 
 static const char * ciphers = "NONE:"
@@ -149,6 +148,7 @@ int SSLi_write(SSL_handle_t *session, uint8_t *buffer, int length)
 
 int SSLi_get_error(SSL_handle_t *session, int code)
 {
+	(void)session; /* TODO: ugly hack to silence compiler. WHY are we not using this? */
 	return code;
 }
 

--- a/src/ssli_mbedtls.c
+++ b/src/ssli_mbedtls.c
@@ -114,6 +114,7 @@ static void initKey()
 int urandom_bytes(void *ctx, unsigned char *dest, size_t len)
 {
 	int cur;
+	(void)ctx; /* TODO: ugly hack to silence compiler. WHY are we not using this? */
 
 	while (len) {
 		cur = read(urandom_fd, dest, len);
@@ -128,6 +129,10 @@ int urandom_bytes(void *ctx, unsigned char *dest, size_t len)
 #define DEBUG_LEVEL 0
 static void pssl_debug(void *ctx, int level, const char *file, int line, const char *str)
 {
+	(void)ctx; /* TODO: ugly hack to silence compiler. WHY are we not using this? */
+	(void)file; /* TODO: ugly hack to silence compiler. WHY are we not using this? */
+	(void)line; /* TODO: ugly hack to silence compiler. WHY are we not using this? */
+
     if (level <= DEBUG_LEVEL)
 		Log_info("mbedTLS [level %d]: %s", level, str);
 }
@@ -215,6 +220,7 @@ SSL_handle_t *SSLi_newconnection(int *fd, bool_t *SSLready)
 	mbedtls_ssl_context *ssl;
 	mbedtls_ssl_session *ssn;
 	int rc;
+	(void)SSLready; /* TODO: ugly hack to silence compiler. WHY are we not using this? */
 
 	ssl = Memory_safeCalloc(1, sizeof(mbedtls_ssl_context));
 	ssn = Memory_safeCalloc(1, sizeof(mbedtls_ssl_session));
@@ -273,6 +279,7 @@ int SSLi_write(SSL_handle_t *ssl, uint8_t *buf, int len)
 
 int SSLi_get_error(SSL_handle_t *ssl, int code)
 {
+	(void)ssl; /* TODO: ugly hack to silence compiler. WHY are we not using this? */
 	return code;
 }
 

--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -85,7 +85,7 @@ static RSA *SSL_readprivatekey(char *keyfile)
 	/* assign a callback function for the password */
 
 	/* read a private key from file */
-	if (PEM_read_RSAPrivateKey(fp, &rsa, NULL, NULL) <= 0) {
+	if (PEM_read_RSAPrivateKey(fp, &rsa, NULL, NULL) != 0) {
 		/* error reading the key - check the error stack */
 		Log_warn("Error trying to read private key.");
 		RSA_free(rsa);

--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -67,32 +67,6 @@ static int SSL_add_ext(X509 * crt, int nid, char *value) {
 	return 1;
 }
 
-static X509 *SSL_readcert(char *certfile)
-{
-	FILE *fp;
-	X509 *x509;
-
-	/* open the certificate file */
-	fp = fopen(certfile, "r");
-	if (fp == NULL) {
-		Log_warn("Unable to open the X509 file %s for reading.", certfile);
-		return NULL;
-	}
-
-	/* allocate memory for the cert structure */
-	x509 = X509_new();
-
-	if (PEM_read_X509(fp, &x509, NULL, NULL) == 0) {
-		/* error reading the x509 information - check the error stack */
-		Log_warn("Error trying to read X509 info.");
-		fclose(fp);
-		X509_free(x509);
-		return NULL;
-	}
-	fclose(fp);
-	return x509;
-}
-
 static RSA *SSL_readprivatekey(char *keyfile)
 {
 	FILE *fp;
@@ -215,7 +189,7 @@ void SSLi_init(void)
 	int i, offset = 0, cipherstringlen = 0;
 	STACK_OF(SSL_CIPHER) *cipherlist = NULL, *cipherlist_new = NULL;
 	SSL_CIPHER *cipher;
-	char *cipherstring;
+	char *cipherstring = NULL;
 
 	SSL_library_init();
 	OpenSSL_add_all_algorithms();
@@ -388,13 +362,11 @@ static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 	char    buf[256];
 	X509   *err_cert;
 	int     err, depth;
-	SSL    *ssl;
 
     err_cert = X509_STORE_CTX_get_current_cert(ctx);
     err = X509_STORE_CTX_get_error(ctx);
     depth = X509_STORE_CTX_get_error_depth(ctx);
 
-    ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
     X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 256);
 
     if (depth > 5) {

--- a/src/voicetarget.c
+++ b/src/voicetarget.c
@@ -45,7 +45,7 @@ void Voicetarget_add_session(client_t *client, int targetId, int sessionId)
 			int i;
 			vt = list_get_entry(itr, voicetarget_t, node);
 			for (i = 0; i < TARGET_MAX_SESSIONS; i++) {
-				if (vt->sessions[i] == -1) {
+				if (vt->sessions[i] == (uint32_t)-1) {
 					vt->sessions[i] = sessionId;
 					Log_debug("Adding session ID %d to voicetarget ID %d", sessionId, targetId);
 					return;

--- a/src/voicetarget.c
+++ b/src/voicetarget.c
@@ -45,7 +45,7 @@ void Voicetarget_add_session(client_t *client, int targetId, int sessionId)
 			int i;
 			vt = list_get_entry(itr, voicetarget_t, node);
 			for (i = 0; i < TARGET_MAX_SESSIONS; i++) {
-				if (vt->sessions[i] == (uint32_t)-1) {
+				if (vt->sessions[i] == UINT32_MAX) {
 					vt->sessions[i] = sessionId;
 					Log_debug("Adding session ID %d to voicetarget ID %d", sessionId, targetId);
 					return;
@@ -66,7 +66,7 @@ void Voicetarget_add_channel(client_t *client, int targetId, int channelId,
 			int i;
 			vt = list_get_entry(itr, voicetarget_t, node);
 			for (i = 0; i < TARGET_MAX_CHANNELS; i++) {
-				if (vt->channels[i].channel == -1) {
+				if (vt->channels[i].channel == UINT32_MAX) {
 					vt->channels[i].channel = channelId;
 					vt->channels[i].linked = linked;
 					vt->channels[i].children = children;
@@ -86,9 +86,9 @@ void Voicetarget_add_id(client_t *client, int targetId)
 	Voicetarget_del_id(client, targetId);
 	newtarget = Memory_safeCalloc(1, sizeof(voicetarget_t));
 	for (i = 0; i < TARGET_MAX_CHANNELS; i++)
-		newtarget->channels[i].channel = -1;
+		newtarget->channels[i].channel = UINT32_MAX;
 	for (i = 0; i < TARGET_MAX_SESSIONS; i++)
-		newtarget->sessions[i] = -1;
+		newtarget->sessions[i] = UINT32_MAX;
 	newtarget->id = targetId;
 	list_add_tail(&newtarget->node, &client->voicetargets);
 }

--- a/src/voicetarget.h
+++ b/src/voicetarget.h
@@ -39,7 +39,7 @@
 #define TARGET_MAX_SESSIONS 32
 
 typedef struct {
-	int channel;
+	uint32_t channel;
 	bool_t linked;
 	bool_t children;
 } channeltarget_t;

--- a/src/voicetarget.h
+++ b/src/voicetarget.h
@@ -47,7 +47,7 @@ typedef struct {
 typedef struct {
 	int id;
 	channeltarget_t channels[TARGET_MAX_CHANNELS];
-	int sessions[TARGET_MAX_SESSIONS];
+	uint32_t sessions[TARGET_MAX_SESSIONS];
 	struct dlist node;
 } voicetarget_t;
 


### PR DESCRIPTION
There were some comparisons between signed and unsigned integers as
well as unused code and missing preprocessor defines. The new flags
helped finding those issues. There are still some open 'issues' marked
with 'TODO:', so simply grep using something like 'grep -r TODO: .'.
Some of the issues might be shortcomings of C, some might be fixable.