### PR TITLE
Add -s flag to force switching users

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -230,11 +230,12 @@ void printhelp()
 {
 	printf("uMurmur version %s ('%s'). Mumble protocol %d.%d.%d\n", UMURMUR_VERSION,
 		UMURMUR_CODENAME, PROTVER_MAJOR, PROTVER_MINOR, PROTVER_PATCH);
-	printf("Usage: umurmurd [-d] [-r] [-h] [-p <pidfile>] [-t] [-c <conf file>] [-a <addr>] [-b <port>]\n");
+	printf("Usage: umurmurd [-d] [-r] [-s] [-h] [-p <pidfile>] [-t] [-c <conf file>] [-a <addr>] [-b <port>]\n");
 	printf("       -d             - Do not daemonize - run in foreground.\n");
 #ifdef POSIX_PRIORITY_SCHEDULING
 	printf("       -r             - Run with realtime priority\n");
 #endif
+	printf("       -s             - Force user switching\n");
 	printf("       -p <pidfile>   - Write PID to this file\n");
 	printf("       -c <conf file> - Specify configuration file (default %s)\n", DEFAULT_CONFIG);
 	printf("       -t             - Test config. Error message to stderr + non-zero exit code on error\n");
@@ -249,6 +250,7 @@ void printhelp()
 int main(int argc, char **argv)
 {
 	bool_t nodaemon = false;
+	bool_t forceswitch = false;
 #ifdef POSIX_PRIORITY_SCHEDULING
 	bool_t realtime = false;
 #endif
@@ -259,9 +261,9 @@ int main(int argc, char **argv)
 
 	/* Arguments */
 #ifdef POSIX_PRIORITY_SCHEDULING
-	while ((c = getopt(argc, argv, "drp:c:a:A:b:B:ht")) != EOF) {
+	while ((c = getopt(argc, argv, "drsp:c:a:A:b:B:ht")) != EOF) {
 #else
-		while ((c = getopt(argc, argv, "dp:c:a:A:b:B:ht")) != EOF) {
+		while ((c = getopt(argc, argv, "dsp:c:a:A:b:B:ht")) != EOF) {
 #endif
 			switch(c) {
 				case 'c':
@@ -296,6 +298,9 @@ int main(int argc, char **argv)
 					realtime = true;
 					break;
 #endif
+				case 's':
+					forceswitch = true;
+					break;
 				default:
 					fprintf(stderr, "Unrecognized option\n");
 					printhelp();
@@ -369,7 +374,7 @@ int main(int argc, char **argv)
     Sharedmemory_init( bindport, bindport6 );
 #endif
 
-		if(!nodaemon) {
+		if(!nodaemon || forceswitch) {
 			/* SSL and scheduling is setup, we can drop privileges now */
 			switch_user();
 


### PR DESCRIPTION
From the commit log:

```
As @C4K3 suggested in issue #105, the -s flag can be used to force
switching to the configured user and group combination without
daemonizing. Since it is best practice to not daemonize when running as
a systemd service, this flag, in combination with -d, allows systemd
users to switch users without daemonizing. Something like the following
would then be used in ExecStart:

  /usr/bin/umurmur -c /etc/umurmur/umurmur.conf -d -s

```