### PR TITLE
Fix error compiling with openssl 1.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,8 +113,8 @@ AS_IF([test "x$with_ssl" = xmbedtls], [
 ])
 AS_IF([test "x$with_ssl" = xopenssl], [
 	AC_CHECK_HEADERS([openssl/ssl.h], [], [AC_MSG_ERROR([could not find openssl/ssl.h])])
-	AC_CHECK_LIB([crypto], [BN_init], [], [AC_MSG_ERROR([could not find libcrypto])])
-	AC_CHECK_LIB([ssl], [SSL_library_init], [], [AC_MSG_ERROR([could not find libssl])])
+	AC_CHECK_LIB([crypto], [CRYPTO_new_ex_data], [], [AC_MSG_ERROR([could not find libcrypto])])
+	AC_CHECK_LIB([ssl], [SSL_new], [], [AC_MSG_ERROR([could not find libssl])])
 ])
 AS_IF([test "x$with_ssl" = xgnutls], [
 	AC_CHECK_HEADERS([gnutls/gnutls.h], [], [AC_MSG_ERROR([could not find gnutls/gnutls.h])])

--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -411,7 +411,7 @@ static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
      * it for something special
      */
     if (!preverify_ok && (err == X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT)) {
-	    X509_NAME_oneline(X509_get_issuer_name(ctx->current_cert), buf, 256);
+	    X509_NAME_oneline(X509_get_issuer_name(err_cert), buf, 256);
 	    Log_warn("issuer= %s", buf);
     }
     return 1;


### PR DESCRIPTION
Would throw a dereferencing pointer to incomplete type previously. This
change is compatible with both openssl 1.1.0 and 1.0.2, the only
supported openssl releases.

Building with autotools and openssl 1.1.0 does still not work.