### PR TITLE
Add autotools deprecation warning

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1567,6 +1567,15 @@ else
     $ECHO "  make"
 fi
 
+$ECHO
+$ECHO "WARNING: Building umurmur with autotools has been deprecated. In the"
+$ECHO "future, support for autotools will be dropped, please switch to"
+$ECHO "compiling with cmake instead. See the links below for information"
+$ECHO "on how to compile with cmake, and the relevant discussion."
+$ECHO
+$ECHO "https://github.com/umurmur/umurmur/wiki/Building"
+$ECHO "https://github.com/umurmur/umurmur/issues/111"
+
 
 # Local Variables:
 # mode: sh


### PR DESCRIPTION
This is one suggestion for how deprecating autotools could look like, if dropping autotools is the final decision.

Adds a warning about autotools being deprecated directly in autogen.sh
Using the m4_warn/m4_errprintn macro causes the warning to not be
displayed with autogen.sh, and using AC_MSG_WARN is only displayed when
configure is run (which might instead be desirable.) This solution
very clearly displays the warning when running autogen.sh.

(Discussion in #111)