### PR TITLE
Fix USE_MBEDTLS_HAVEGE compile

### DIFF
--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -3,7 +3,7 @@ option(USE_POLARSSL_TESTCERT "Link to the PolarSSL test certificate and key." OF
 option(USE_POLARSSL_HAVEGE "Use the PolarSSL HAVEGE random generator key." OFF)
 
 if(USE_POLARSSL_TESTCERT OR USE_POLARSSL_HAVEGE)
-  if(SSL NOT MATCHES "polarssl")
+  if(NOT SSL MATCHES "polarssl")
     message(FATAL_ERROR "Selecting USE_POLARSSL_TESTCERT or USE_POLARSSL_HAVEGE implies SSL=polarssl")
   endif()
 endif()
@@ -13,7 +13,7 @@ option(USE_MBEDTLS_TESTCERT "Link to the mbedTLS test certificate and key." OFF)
 option(USE_MBEDTLS_HAVEGE "Use the mbedTLS HAVEGE random generator key." OFF)
 
 if(USE_MBEDTLS_TESTCERT OR USE_MBEDTLS_HAVEGE)
-  if(SSL NOT MATCHES "mbedtls")
+  if(NOT SSL MATCHES "mbedtls")
     message(FATAL_ERROR "Selecting USE_MBEDTLS_TESTCERT or USE_MBEDTLS_HAVEGE implies SSL=mbedtls")
   endif()
 endif()

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -43,8 +43,10 @@
 #include "crypt.h"
 #include "ssl.h"
 
-#if defined(USE_POLARSSL_HAVEGE) || defined(USE_MBEDTLS_HAVEGE)
+#if defined(USE_POLARSSL_HAVEGE)
 extern havege_state hs;
+#elif defined(USE_MBEDTLS_HAVEGE)
+extern mbedtls_havege_state hs;
 #endif
 
 static void CryptState_ocb_encrypt(cryptState_t *cs, const unsigned char *plain, unsigned char *encrypted, unsigned int len, const unsigned char *nonce, unsigned char *tag);

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -104,7 +104,7 @@ typedef	ssl_context SSL_handle_t;
 
 #if defined(USE_MBEDTLS_HAVEGE)
 #include <mbedtls/havege.h>
-    #define HAVEGE_RAND (havege_random)
+    #define HAVEGE_RAND (mbedtls_havege_random)
     #define RAND_bytes(_dst_, _size_) do { \
         mbedtls_havege_random(&hs, _dst_, _size_); \
     } while (0)

--- a/src/ssli_mbedtls.c
+++ b/src/ssli_mbedtls.c
@@ -42,7 +42,11 @@
 #include <mbedtls/certs.h>
 #include <mbedtls/x509.h>
 #include <mbedtls/ssl.h>
+#if (MBEDTLS_VERSION_MINOR > 3)
+#include <mbedtls/net_sockets.h>
+#else
 #include <mbedtls/net.h>
+#endif
 #include <mbedtls/sha1.h>
 
 const int ciphers[] =
@@ -75,7 +79,7 @@ static mbedtls_pk_context key;
 bool_t builtInTestCertificate;
 
 #ifdef USE_MBEDTLS_HAVEGE
-havege_state hs;
+mbedtls_havege_state hs;
 #else
 int urandom_fd;
 #endif
@@ -196,6 +200,13 @@ void SSLi_deinit(void)
 	free(conf);
 	mbedtls_x509_crt_free(&certificate);
 	mbedtls_pk_free(&key);
+
+#ifdef USE_MBEDTLS_HAVEGE
+        mbedtls_havege_free(&hs);
+#else
+        close(urandom_fd);
+#endif
+
 }
 
 bool_t SSLi_getSHA1Hash(SSL_handle_t *ssl, uint8_t *hash)


### PR DESCRIPTION
Fix uMurmur compilation errors when using USE_MBEDTLS_HAVEGE build directive.