### PR TITLE
Correcting implicit function declarations

### DIFF
--- a/src/ban.c
+++ b/src/ban.c
@@ -29,6 +29,9 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    */
 
+#define _POSIX_C_SOURCE 200809L
+#define _XOPEN_SOURCE
+
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>


### PR DESCRIPTION
```
../src/ban.c:274:3: warning: implicit declaration of function 'strptime' is invalid in C99 [-Wimplicit-function-declaration]
                strptime(start, "%Y-%m-%dT%H:%M:%S", &timespec);
                ^
../src/ban.c:83:16: warning: implicitly declaring library function 'strdup' with type 'char *(const char *)' [-Wimplicit-function-declaration]                                                
        ban->reason = strdup(reason);                                                          
                      ^                                                                        
../src/ban.c:83:16: note: include the header <string.h> or explicitly provide a declaration for 'strdup'                                                                                      
../src/ban.c:276:3: warning: implicit declaration of function 'setenv' is invalid in C99 [-Wimplicit-function-declaration]
                setenv("TZ", "UTC", 1);
                ^
../src/ban.c:282:4: warning: implicit declaration of function 'unsetenv' is invalid in C99 [-Wimplicit-function-declaration]
                        unsetenv("TZ");
                        ^
4 warnings generated.
```