### PR TITLE
sys/poll.h ~> poll.h [POSIX]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ AC_DEFINE([DEFAULT_CONFIG], ["/etc/umurmur.conf"], [Default config])
 
 # Checks for header files.
 AC_FUNC_ALLOCA
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h limits.h netinet/tcp.h stddef.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h sys/poll.h], [], [AC_MSG_ERROR([missing a required header])])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h limits.h netinet/tcp.h stddef.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h poll.h], [], [AC_MSG_ERROR([missing a required header])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/src/client.c
+++ b/src/client.c
@@ -28,11 +28,11 @@
    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    */
-#include <sys/poll.h>
 #include <sys/socket.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <limits.h>
+#include <poll.h>
 #include <stdlib.h>
 #include <string.h>
 #include "log.h"

--- a/src/client.h
+++ b/src/client.h
@@ -39,7 +39,7 @@
 #include <netinet/in.h>         /* IPPROTO_TCP */
 #include <arpa/inet.h>          /* inet_addr() */
 #include <errno.h>              /* errno */
-#include <sys/poll.h>
+#include <poll.h>
 
 #include "list.h"
 #include "types.h"

--- a/src/server.c
+++ b/src/server.c
@@ -30,12 +30,12 @@
 */
 #include <stdio.h>
 #include <sys/time.h>
-#include <sys/poll.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <errno.h>
 #include <string.h>
 #include <limits.h>
+#include <poll.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>


### PR DESCRIPTION
Relying on POSIX `<poll.h>` instead of glibc-_specific_ `<sys/poll.h>`.