### PR TITLE
Fix default configuration file location.

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -11,6 +11,6 @@
 
 #cmakedefine USE_SHAREDMEMORY_API
 
-#define DEFAULT_CONFIG "${CMAKE_INSTALL_PREFIX}/etc/umurmur.conf"
+#define DEFAULT_CONFIG "${CMAKE_INSTALL_SYSCONFDIR}/etc/umurmur.conf"
 
 #endif // CONFIG_H


### PR DESCRIPTION
Use CMAKE_INSTALL_SYSCONFDIR instead of CMAKE_INSTALL_PREFIX as base for default location of config file.

Signed-off-by: Martin Johansson <martin@fatbob.nu>