### PR TITLE
Install config to CMAKE_INSTALL_SYSCONFDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,15 +18,16 @@ SelectTLSBackend("${SSL}")
 
 include(Options)
 include(Tools)
+include(GNUInstallDirs)
 
 find_package(Libconfig REQUIRED)
 find_package(ProtobufC REQUIRED)
 
 add_subdirectory(src)
 
-find_path(OLD_CONFIG_FILE NAMES "umurmur.conf" PATHS ${CMAKE_INSTALL_PREFIX} PATH_SUFFIXES "etc")
-
-if(NOT OLD_CONFIG_FILE)
-  install(FILES "umurmur.conf.example" DESTINATION "etc" RENAME "umurmur.conf")
-endif()
-
+install(
+  FILES "umurmur.conf.example"
+  DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/umurmur"
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
+  RENAME "umurmur.conf"
+)


### PR DESCRIPTION
CMakeLists.txt:
Include GNUInstallDirs and use CMAKE_INSTALL_SYSCONFDIR to install the
example configuration (defaults to /etc/umurmur/umurmur.conf). The
configuration is installed with 0640 permissions as it may contain
passwords and therefore should not be world readable.
Remove prior checks to the system for umurmur.conf as the merging or
backup of configuration files is historically taken care of by a package
management system on a target system.