### PR TITLE
Install config to /etc/umurmur.conf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory(src)
 
 install(
   FILES "umurmur.conf.example"
-  DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/umurmur"
+  DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}/"
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
   RENAME "umurmur.conf"
 )


### PR DESCRIPTION
CMakeLists.txt:
The changes introduced in #164 install the configuration to
/etc/umurmur/umurmur.conf by default. However, umurmurd is picking up
the configuration from /etc/umurmur.conf automatically, which makes that
location a more logical default.