### PR TITLE
Namespace default configuration file location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory(src)
 
 install(
   FILES "umurmur.conf.example"
-  DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/"
+  DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/umurmur"
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
   RENAME "umurmur.conf"
 )

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -8,6 +8,6 @@
 
 #cmakedefine USE_SHAREDMEMORY_API
 
-#define DEFAULT_CONFIG "${CMAKE_INSTALL_FULL_SYSCONFDIR}/umurmur.conf"
+#define DEFAULT_CONFIG "${CMAKE_INSTALL_FULL_SYSCONFDIR}/umurmur/umurmur.conf"
 
 #endif // CONFIG_H


### PR DESCRIPTION
src/config.h.in:
Namespace the default configuration file location with the project's
name "umurmur", as in that location also the required certificates are
expected by default and using a namespaced location makes sense as to
not clutter the SYSCONFDIR (e.g. /etc/) with more files, as a namespace
is necessary anyways.

CMakeLists.txt:
Install the default configuration file to a "umurmur" namespaced
location.

Fixes #169