### PR TITLE
work around initgroups(3) invalidating data returned by getgrnam(3)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -149,6 +149,9 @@ static void switch_user(void)
 			Log_fatal("Unknown group '%s'", groupname);
 
 		gid = grp->gr_gid;
+
+		/* initgroups() will invalidate this data */
+		grp = NULL;
 	}
 
 	if (initgroups(pwd->pw_name, gid))
@@ -160,8 +163,7 @@ static void switch_user(void)
 	if (setuid(pwd->pw_uid))
 		Log_fatal("setuid() failed: %s", strerror(errno));
 
-	if (!grp)
-		grp = getgrgid(gid);
+	grp = getgrgid(gid);
 	if (!grp)
 		Log_fatal("getgrgid() failed: %s", strerror(errno));
 


### PR DESCRIPTION
initgroups(3) uses getgrouplist(3) that may use getgrent(3) and so invalidating data returned by prior calls to getgrnam(3).

In this case, umurmurd would print that it had switched to another group.  Fortunately, it's only the log message wrong, umurmurd correctly switches to the target user/group.

Initially reported by Raf Czlonka for the OpenBSD package: <https://marc.info/?l=openbsd-ports&m=167759133628650&w=2>