### PR TITLE
Update CMake configuration to locate libraries and install to /sbin

### DIFF
--- a/cmake/Modules/FindLibconfig.cmake
+++ b/cmake/Modules/FindLibconfig.cmake
@@ -1,10 +1,6 @@
 include(FindPackageHandleStandardArgs)
 
-find_path(LIBCONFIG_INCLUDE_DIR NAMES "libconfig.h" PATHS /usr/pkg /usr/local /usr PATH_SUFFIXES "include")
-find_path(LIBCONFIG_LIB_DIR NAMES "libconfig.so" "libconfig.dylib" PATHS /usr/pkg /usr/local /usr PATH_SUFFIXES "lib" "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+find_path(LIBCONFIG_INCLUDE_DIR NAMES "libconfig.h")
+find_library(LIBCONFIG_LIBRARIES NAMES "config")
 
-if(LIBCONFIG_INCLUDE_DIR AND LIBCONFIG_LIB_DIR)
-  set(LIBCONFIG_LIBRARIES config)
-endif(LIBCONFIG_INCLUDE_DIR AND LIBCONFIG_LIB_DIR)
-
-find_package_handle_standard_args(Libconfig DEFAULT LIBCONFIG_INCLUDE_DIR LIBCONFIG_LIBRARIES LIBCONFIG_LIB_DIR)
+find_package_handle_standard_args(Libconfig REQUIRED_VARS LIBCONFIG_INCLUDE_DIR LIBCONFIG_LIBRARIES)

--- a/cmake/Modules/FindProtobufC.cmake
+++ b/cmake/Modules/FindProtobufC.cmake
@@ -1,10 +1,7 @@
 include(FindPackageHandleStandardArgs)
 
-find_path(PROTOBUFC_INCLUDE_DIR NAMES "protobuf-c.h" PATHS /usr/pkg /usr/local /usr PATH_SUFFIXES "include/google/protobuf-c")
-find_path(PROTOBUFC_LIB_DIR NAMES "libprotobuf-c.so" "libprotobuf-c.dylib" PATHS /usr/pkg /usr/local /usr PATH_SUFFIXES "lib"  "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+find_path(PROTOBUFC_INCLUDE_DIR NAMES "protobuf-c.h" PATH_SUFFIXES "protobuf-c")
+find_library(PROTOBUFC_LIBRARIES NAMES "protobuf-c")
 
-if(PROTOBUFC_INCLUDE_DIR AND PROTOBUFC_LIB_DIR)
-  set(PROTOBUFC_LIBRARIES protobuf-c)
-endif(PROTOBUFC_INCLUDE_DIR AND PROTOBUFC_LIB_DIR)
 
-find_package_handle_standard_args(ProtobufC REQUIRED_VARS PROTOBUFC_INCLUDE_DIR PROTOBUFC_LIBRARIES PROTOBUFC_LIB_DIR)
+find_package_handle_standard_args(ProtobufC REQUIRED_VARS PROTOBUFC_INCLUDE_DIR PROTOBUFC_LIBRARIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(${PROJECT_NAME}
                       ${LIBRT}
                       ${CRYPTO_LIBRARIES})
 
-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "bin")
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "sbin")


### PR DESCRIPTION
This pulls a couple patches from OpenBSD, specifically those around CMake configuration. Simplifies and resolves compilation on BSD.

Source: https://github.com/openbsd/ports/tree/master/audio/umurmur/patches