### PR TITLE
Potential fix for code scanning alert no. 1: Too few arguments to formatting function

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -524,7 +524,7 @@ int Client_read(client_t *client)
 						Log_info_client(client, "Connection closed by peer");
 					else
 						Log_info_client(client,"Error: %s  - Closing connection (code %d)",
-							strerror(errno));
+							strerror(errno), errno);
 				}
 				else if (SSLi_get_error(client->ssl, rc) == SSLI_ERROR_CONNRESET) {
 					Log_info_client(client, "Connection reset by peer");


### PR DESCRIPTION
Potential fix for [https://github.com/umurmur/umurmur/security/code-scanning/1](https://github.com/umurmur/umurmur/security/code-scanning/1)

To fix the problem, we need to ensure that the number of arguments passed to the `Log_info_client` function matches the number of format specifiers in the format string. In this case, the format string expects two arguments: a string and an integer. We need to provide both arguments to the function.

The best way to fix this without changing existing functionality is to add the missing argument to the `Log_info_client` call. The missing argument is the error code, which can be obtained from the `errno` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
