### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,6 @@
 name: Build with Docker
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umurmur/umurmur/security/code-scanning/2](https://github.com/umurmur/umurmur/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to the minimum required for the workflow. Since the workflow only checks out code and builds Docker images, it does not require any write permissions. The `contents: read` permission is sufficient for the `actions/checkout` step to function correctly.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply the permissions globally to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
