### PR TITLE
chore: Migrate to OpenSSL EVP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ uMurmur is a minimalistic Mumble server primarily targeted to run on embedded co
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
-        <a href=https://github.com/dvzrv>
-            <img src=https://avatars.githubusercontent.com/u/432519?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=David Runge/>
+        <a href=https://github.com/concatime>
+            <img src=https://avatars.githubusercontent.com/u/26262387?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Issam E. Maghni/>
             <br />
-            <sub style="font-size:12px"><b>David Runge</b></sub>
+            <sub style="font-size:12px"><b>Issam E. Maghni</b></sub>
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
@@ -71,17 +71,10 @@ uMurmur is a minimalistic Mumble server primarily targeted to run on embedded co
 </tr>
 <tr>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
-        <a href=https://github.com/concatime>
-            <img src=https://avatars.githubusercontent.com/u/26262387?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Issam E. Maghni/>
+        <a href=https://github.com/dvzrv>
+            <img src=https://avatars.githubusercontent.com/u/432519?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=David Runge/>
             <br />
-            <sub style="font-size:12px"><b>Issam E. Maghni</b></sub>
-        </a>
-    </td>
-    <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
-        <a href=https://github.com/Trivve>
-            <img src=https://avatars.githubusercontent.com/u/6183628?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Andreas/>
-            <br />
-            <sub style="font-size:12px"><b>Andreas</b></sub>
+            <sub style="font-size:12px"><b>David Runge</b></sub>
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
@@ -89,6 +82,13 @@ uMurmur is a minimalistic Mumble server primarily targeted to run on embedded co
             <img src=https://avatars.githubusercontent.com/u/118243?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Dan Turner/>
             <br />
             <sub style="font-size:12px"><b>Dan Turner</b></sub>
+        </a>
+    </td>
+    <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
+        <a href=https://github.com/Trivve>
+            <img src=https://avatars.githubusercontent.com/u/6183628?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Andreas/>
+            <br />
+            <sub style="font-size:12px"><b>Andreas</b></sub>
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ uMurmur is a minimalistic Mumble server primarily targeted to run on embedded co
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
-        <a href=https://github.com/concatime>
-            <img src=https://avatars.githubusercontent.com/u/26262387?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Issam E. Maghni/>
+        <a href=https://github.com/dvzrv>
+            <img src=https://avatars.githubusercontent.com/u/432519?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=David Runge/>
             <br />
-            <sub style="font-size:12px"><b>Issam E. Maghni</b></sub>
+            <sub style="font-size:12px"><b>David Runge</b></sub>
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
@@ -71,17 +71,10 @@ uMurmur is a minimalistic Mumble server primarily targeted to run on embedded co
 </tr>
 <tr>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
-        <a href=https://github.com/dvzrv>
-            <img src=https://avatars.githubusercontent.com/u/432519?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=David Runge/>
+        <a href=https://github.com/concatime>
+            <img src=https://avatars.githubusercontent.com/u/26262387?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Issam E. Maghni/>
             <br />
-            <sub style="font-size:12px"><b>David Runge</b></sub>
-        </a>
-    </td>
-    <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
-        <a href=https://github.com/TinnedTuna>
-            <img src=https://avatars.githubusercontent.com/u/118243?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Dan Turner/>
-            <br />
-            <sub style="font-size:12px"><b>Dan Turner</b></sub>
+            <sub style="font-size:12px"><b>Issam E. Maghni</b></sub>
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
@@ -89,6 +82,13 @@ uMurmur is a minimalistic Mumble server primarily targeted to run on embedded co
             <img src=https://avatars.githubusercontent.com/u/6183628?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Andreas/>
             <br />
             <sub style="font-size:12px"><b>Andreas</b></sub>
+        </a>
+    </td>
+    <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">
+        <a href=https://github.com/TinnedTuna>
+            <img src=https://avatars.githubusercontent.com/u/118243?v=4 width="100;"  style="border-radius:50%;align-items:center;justify-content:center;overflow:hidden;padding-top:10px" alt=Dan Turner/>
+            <br />
+            <sub style="font-size:12px"><b>Dan Turner</b></sub>
         </a>
     </td>
     <td align="center" style="word-wrap: break-word; width: 150.0; height: 150.0">

--- a/src/client.c
+++ b/src/client.c
@@ -395,6 +395,7 @@ void Client_free(client_t *client)
 	Client_codec_free(client);
 	Voicetarget_free_all(client);
 	Client_token_free(client);
+	CryptState_cleanup(&client->cryptState);
 
 	list_del(&client->node);
 	if (client->ssl)

--- a/src/crypt.h
+++ b/src/crypt.h
@@ -34,12 +34,21 @@
 #include "byteorder.h"
 #include "config.h"
 
+typedef struct CryptState cryptState_t;
+
+/*
+ * AES uses a fixed 16-byte block size across supported backends.
+ */
+#ifndef AES_BLOCK_SIZE
+#define AES_BLOCK_SIZE 16
+#endif
+
+/* Crypto backend: mbedTLS */
 #if defined(USE_MBEDTLS)
 
 #include <mbedtls/aes.h>
 
 #define CRYPT_AES_KEY mbedtls_aes_context
-#define AES_BLOCK_SIZE 16
 
 #define CRYPT_RANDOM_BYTES(dest, size) RAND_bytes((unsigned char *)(dest), (size))
 #define CRYPT_SET_ENC_KEY(dest, source, size) mbedtls_aes_setkey_enc((dest), (source), (size));
@@ -48,6 +57,7 @@
 #define CRYPT_AES_ENCRYPT(src, dst, cryptstate) mbedtls_aes_crypt_ecb(&(cryptstate)->encrypt_key, MBEDTLS_AES_ENCRYPT, (unsigned char *)(src), (unsigned char *)(dst));
 #define CRYPT_AES_DECRYPT(src, dst, cryptstate) mbedtls_aes_crypt_ecb(&(cryptstate)->decrypt_key, MBEDTLS_AES_DECRYPT, (unsigned char *)(src), (unsigned char *)(dst));
 
+/* Crypto backend: GnuTLS/nettle */
 #elif defined(USE_GNUTLS)
 
 #include <nettle/aes.h>
@@ -62,18 +72,24 @@
 #define CRYPT_AES_ENCRYPT(src, dest, ctx) aes128_encrypt(&(ctx)->encrypt_key, AES_BLOCK_SIZE, (uint8_t *)(dest), (uint8_t *)(src))
 #define CRYPT_AES_DECRYPT(src, dest, ctx) aes128_decrypt(&(ctx)->decrypt_key, AES_BLOCK_SIZE, (uint8_t *)(dest), (uint8_t *)(src))
 
+/* Crypto backend: OpenSSL */
 #else
 
 #include <openssl/rand.h>
-#include <openssl/aes.h>
+#include <openssl/evp.h>
 
-#define CRYPT_AES_KEY AES_KEY
+#define CRYPT_AES_KEY EVP_CIPHER_CTX *
 #define CRYPT_RANDOM_BYTES(dest, size) RAND_bytes((unsigned char *)(dest), (size))
-#define CRYPT_SET_ENC_KEY(dest, source, size) AES_set_encrypt_key((source), (size), (dest));
-#define CRYPT_SET_DEC_KEY(dest, source, size) AES_set_decrypt_key((source), (size), (dest));
+void CryptState_setEncryptKey(CRYPT_AES_KEY *dest, const unsigned char *source, int size);
+void CryptState_setDecryptKey(CRYPT_AES_KEY *dest, const unsigned char *source, int size);
+void CryptState_aesEncrypt(const unsigned char *src, unsigned char *dst, cryptState_t *cs);
+void CryptState_aesDecrypt(const unsigned char *src, unsigned char *dst, cryptState_t *cs);
 
-#define CRYPT_AES_ENCRYPT(src, dst, cryptstate) AES_encrypt((unsigned char *)(src), (unsigned char *)(dst), &(cryptstate)->encrypt_key);
-#define CRYPT_AES_DECRYPT(src, dst, cryptstate) AES_decrypt((unsigned char *)(src), (unsigned char *)(dst), &(cryptstate)->decrypt_key);
+#define CRYPT_SET_ENC_KEY(dest, source, size) CryptState_setEncryptKey((dest), (source), (size))
+#define CRYPT_SET_DEC_KEY(dest, source, size) CryptState_setDecryptKey((dest), (source), (size))
+
+#define CRYPT_AES_ENCRYPT(src, dst, cryptstate) CryptState_aesEncrypt((const unsigned char *)(src), (unsigned char *)(dst), (cryptstate))
+#define CRYPT_AES_DECRYPT(src, dst, cryptstate) CryptState_aesDecrypt((const unsigned char *)(src), (unsigned char *)(dst), (cryptstate))
 
 #endif
 
@@ -81,7 +97,7 @@
 #include "timer.h"
 #include "types.h"
 
-typedef struct CryptState {
+struct CryptState {
 	uint8_t raw_key[AES_BLOCK_SIZE];
 	uint8_t encrypt_iv[AES_BLOCK_SIZE];
 	uint8_t decrypt_iv[AES_BLOCK_SIZE];
@@ -103,13 +119,14 @@ typedef struct CryptState {
 	etimer_t tLastGood;
 	etimer_t tLastRequest;
 	bool_t bInit;
-} cryptState_t;
+};
 
 void CryptState_init(cryptState_t *cs);
 bool_t CryptState_isValid(cryptState_t *cs);
 void CryptState_genKey(cryptState_t *cs);
 void CryptState_setKey(cryptState_t *cs, const unsigned char *rkey, const unsigned char *eiv, const unsigned char *div);
 void CryptState_setDecryptIV(cryptState_t *cs, const unsigned char *iv);
+void CryptState_cleanup(cryptState_t *cs);
 
 bool_t CryptState_decrypt(cryptState_t *cs, const unsigned char *source, unsigned char *dst, unsigned int crypted_length);
 void CryptState_encrypt(cryptState_t *cs, const unsigned char *source, unsigned char *dst, unsigned int plain_length);

--- a/src/main.c
+++ b/src/main.c
@@ -206,6 +206,7 @@ void daemonize(void)
 		close(i); /* close all descriptors */
 
 #ifdef USE_GNUTLS
+	/* TLS backend: GnuTLS requires explicit global initialization. */
 	 gnutls_global_init();
 #endif
 

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include <string.h>
 
+/* TLS backend: mbedTLS */
 #if defined(USE_MBEDTLS)
 #include <mbedtls/version.h>
 
@@ -77,6 +78,7 @@ int urandom_bytes(void *ctx, unsigned char *dest, size_t len);
 
 typedef	mbedtls_ssl_context SSL_handle_t;
 
+/* TLS backend: GnuTLS */
 #elif defined(USE_GNUTLS)
 
 #include <gnutls/gnutls.h>
@@ -89,7 +91,8 @@ typedef	mbedtls_ssl_context SSL_handle_t;
 
 typedef gnutls_session_t SSL_handle_t;
 
-#else /* OpenSSL */
+/* TLS backend: OpenSSL */
+#else
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>
 
@@ -118,9 +121,10 @@ void SSLi_free(SSL_handle_t *ssl);
 
 static inline void SSLi_hash2hex(uint8_t *hash, char *out)
 {
-	int i, offset = 0;
+	int i;
 	for (i = 0; i < 20; i++)
-		offset += snprintf(out + offset, sizeof(out + offset), "%02x", hash[i]);
+		snprintf(out + (i * 2), 3, "%02x", hash[i]);
+	out[40] = '\0';
 }
 
 static inline void SSLi_hex2hash(char *in, uint8_t *hash)


### PR DESCRIPTION
This clears up the deprecation warnings around OpenSSL builds, instead using the high-level Envelope API.

Fixes #222

