### PR TITLE
feat: Reload certificate on SIGHUP

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -392,18 +392,15 @@ int main(int argc, char **argv)
 			if (unveil(pidfile, "c") == -1)
 				Log_fatal("unveil pidfile (%s) failed: %s", pidfile, strerror(errno));
 
-		if (getBoolConf(ENABLE_BAN)) {
-			const char *banfile = getStrConf(BANFILE);
-			if (banfile && *banfile)
-				if (unveil(banfile, "wc") == -1)
-					Log_fatal("unveil banfile (%s) failed: %s", banfile, strerror(errno));
-		}
+		const char *banfile = getStrConf(BANFILE);
+		if (getBoolConf(ENABLE_BAN) && banfile && *banfile)
+			if (unveil(banfile, "wc") == -1)
+				Log_fatal("unveil banfile (%s) failed: %s", banfile, strerror(errno));
 
 		const char *logfile = getStrConf(LOGFILE);
-		if (logfile && *logfile) {
+		if (logfile && *logfile)
 			if (unveil(logfile, "wc") == -1)
 				Log_fatal("unveil logfile (%s) failed: %s", logfile, strerror(errno));
-		}
 
 		const char *crtfile = getStrConf(CERTIFICATE);
 		if (crtfile && *crtfile)

--- a/src/main.c
+++ b/src/main.c
@@ -177,8 +177,9 @@ void signal_handler(int sig)
 			Server_shutdown();
 			break;
 		case SIGHUP:
-			Log_info("HUP signal received. Reopening log file.");
+			Log_info("HUP signal received. Reopening log file and reloading certificate.");
 			Log_reset();
+			SSLi_reload_cert();
 			break;
 		case SIGTERM:
 			Log_info("TERM signal received. Shutting down.");
@@ -264,10 +265,6 @@ int main(int argc, char **argv)
 	bool_t realtime = false;
 #endif
 	bool_t testconfig = false;
-#ifdef __OpenBSD__
-	bool_t needs_filesystem = false;
-	const char *pledge_promises;
-#endif
 	char *conffile = NULL, *pidfile = NULL;
 	int c;
 	struct utsname utsbuf;
@@ -391,43 +388,39 @@ int main(int argc, char **argv)
 		}
 
 #ifdef __OpenBSD__
-		if (pidfile && *pidfile) {
+		if (pidfile && *pidfile)
 			if (unveil(pidfile, "c") == -1)
 				Log_fatal("unveil pidfile (%s) failed: %s", pidfile, strerror(errno));
-			needs_filesystem = true;
-		}
 
 		if (getBoolConf(ENABLE_BAN)) {
 			const char *banfile = getStrConf(BANFILE);
-			if (banfile && *banfile) {
+			if (banfile && *banfile)
 				if (unveil(banfile, "wc") == -1)
 					Log_fatal("unveil banfile (%s) failed: %s", banfile, strerror(errno));
-				needs_filesystem = true;
-			}
 		}
 
 		const char *logfile = getStrConf(LOGFILE);
 		if (logfile && *logfile) {
 			if (unveil(logfile, "wc") == -1)
 				Log_fatal("unveil logfile (%s) failed: %s", logfile, strerror(errno));
-			needs_filesystem = true;
 		}
+
+		const char *crtfile = getStrConf(CERTIFICATE);
+		if (crtfile && *crtfile)
+			if (unveil(crtfile, "r") == -1)
+				Log_fatal("unveil certificate (%s) failed: %s", crtfile, strerror(errno));
+
 
 #ifdef USE_SHAREDMEMORY_API
 		if (unveil("/tmp", "c") == -1)
 			Log_fatal("unveil shared memory directory (/tmp) failed: %s", strerror(errno));
-		needs_filesystem = true;
 #endif
 
 		if (unveil(NULL, NULL) == -1)
 			Log_fatal("unveil lock failed: %s", strerror(errno));
 
-		pledge_promises = "stdio inet";
-		if (needs_filesystem)
-			pledge_promises = "stdio inet wpath cpath";
-
-		if (pledge(pledge_promises, NULL) == -1)
-			Log_fatal("pledge (%s) failed: %s", pledge_promises, strerror(errno));
+		if (pledge("stdio inet wpath cpath", NULL) == -1)
+			Log_fatal("pledge failed: %s", strerror(errno));
 #endif
 
 		Server_run();

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -108,6 +108,7 @@ typedef SSL SSL_handle_t;
 
 void SSLi_init(void);
 void SSLi_deinit(void);
+void SSLi_reload_cert(void);
 SSL_handle_t *SSLi_newconnection(int *fd, bool_t *SSLready);
 bool_t SSLi_getSHA1Hash(SSL_handle_t *ssl, uint8_t *hash);
 void SSLi_closeconnection(SSL_handle_t *ssl);

--- a/src/ssli_gnutls.c
+++ b/src/ssli_gnutls.c
@@ -91,6 +91,12 @@ void SSLi_deinit()
 	gnutls_global_deinit();
 }
 
+/* stub */
+void SSLi_reload_cert(void)
+{
+	return;
+}
+
 SSL_handle_t * SSLi_newconnection( int * fileDescriptor, bool_t * isSSLReady )
 {
 	gnutls_session_t * session

--- a/src/ssli_mbedtls.c
+++ b/src/ssli_mbedtls.c
@@ -273,6 +273,12 @@ void SSLi_deinit(void)
 #endif
 }
 
+/* stub */
+void SSLi_reload_cert(void)
+{
+	return;
+}
+
 bool_t SSLi_getSHA1Hash(SSL_handle_t *ssl, uint8_t *hash)
 {
 	mbedtls_x509_crt const *cert;

--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -32,6 +32,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <sys/stat.h>
+
 #include "conf.h"
 #include "log.h"
 #include "memory.h"
@@ -83,6 +85,10 @@ static void SSL_writecert(char *certfile, X509 *x509)
 		Log_warn("Error trying to write X509 info.");
 	}
 	fclose(fp);
+
+	if (chmod(certfile, 0644) < 0) {
+		Log_warn("Failed to set permissions on certificate file %s", certfile);
+	}
 }
 
 static void SSL_writekey(char *keyfile, EVP_PKEY *pkey)
@@ -298,6 +304,52 @@ void SSLi_deinit(void)
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 	EVP_cleanup();
 #endif
+}
+
+void SSLi_reload_cert(void)
+{
+	char *crt = (char *)getStrConf(CERTIFICATE);
+	FILE *fp;
+	X509 *new_cert = NULL;
+	EVP_PKEY *pkey = NULL;
+
+	if (!crt)
+		return;
+
+	/* OpenSSL >= 1.1.0 */
+	pkey = SSL_CTX_get0_privatekey(context);
+	if (!pkey) {
+		Log_warn("SSL: No private key found in current context.");
+		return;
+	}
+
+	fp = fopen(crt, "r");
+	if (!fp) {
+		Log_warn("Failed to open certificate file %s", crt);
+		return;
+	}
+	new_cert = PEM_read_X509(fp, NULL, NULL, NULL);
+	fclose(fp);
+	if (!new_cert) {
+		Log_warn("Failed to parse certificate file.");
+		return;
+	}
+
+	if (X509_check_private_key(new_cert, pkey) != 1) {
+		Log_warn("New certificate does not match private key.");
+		goto cleanup;
+	}
+
+	if (SSL_CTX_use_certificate(context, new_cert) != 1) {
+		Log_warn("Failed to apply new certificate to context.");
+		goto cleanup;
+	}
+
+	Log_info("Certificate reloaded.");
+
+cleanup:
+	X509_free(new_cert);
+	return;
 }
 
 int SSLi_nonblockaccept(SSL_handle_t *ssl, bool_t *SSLready)


### PR DESCRIPTION
On `SIGHUP`, open the certificate and apply it to the existing context. If the certificate doesn't match the private key: abort the reload. 

This required the following changes:
* Make the certificate world readable so the dropped privilege user can read it later in life cycle.
* Simplify OpenBSD pledge rules since the daemon will always implicitly need read access for certificate.

This is a draft for now as I've only implemented OpenSSL. Note the use of [`SSL_CTX_get0_privatekey();`](https://github.com/umurmur/umurmur/compare/master...amrfti:umurmur:sighup-cert-reload?expand=1#diff-0a5618e95fcf9445179bf864c06243598cc8977d3358ba1144ebaf79ce3dc435R320) requires at least OpenSSL >= [`1.1.1`](https://docs.openssl.org/1.1.1/man7/ssl/#dealing-with-protocol-contexts) which is [EOL 2023](https://openssl-library.org/post/2023-06-15-1.1.1-eol-reminder). I'm not sure if the project is still interested in maintaining backwards compatability with conditionals.

Also would like feedback on the logging if it should be... more verbose, less verbose, more accurate/helpful :)

Closes #91