### PR TITLE
fix: Wsometimes-uninitialized

### DIFF
--- a/src/messages.c
+++ b/src/messages.c
@@ -70,7 +70,7 @@ static void Msg_getPreamble(uint8_t *buffer, int *type, int *len)
 #define MAX_MSGSIZE (BUFSIZE - PREAMBLE_SIZE)
 int Msg_messageToNetwork(message_t *msg, uint8_t *buffer)
 {
-	int len;
+	int len = 0;
 	uint8_t *bufptr = buffer + PREAMBLE_SIZE;
 
 	Log_debug("To net: msg type %d", msg->messageType);


### PR DESCRIPTION
For portability: `len` should be initialized to 0.
```
/tmp/umurmur/src/messages.c:88:7: warning: variable 'len' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]
   88 |                 if (msg->payload.UDPTunnel->packet.len > MAX_MSGSIZE) {
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/umurmur/src/messages.c:266:9: note: uninitialized use occurs here
  266 |         return len + PREAMBLE_SIZE;
      |                ^~~
/tmp/umurmur/src/messages.c:88:3: note: remove the 'if' if its condition is always false
   88 |                 if (msg->payload.UDPTunnel->packet.len > MAX_MSGSIZE) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   89 |                         Log_warn("Too big tx message. Discarding");
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   90 |                         break;
      |                         ~~~~~~
   91 |                 }
      |                 ~
/tmp/umurmur/src/messages.c:73:9: note: initialize the variable 'len' to silence this warning
   73 |         int len;
      |                ^
      |                 = 0
1 warning generated.
```