### PR TITLE
fix: Simplify extension feature-test macros

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,10 +49,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
   _GNU_SOURCE
-  _BSD_SOURCE
-  _NETBSD_SOURCE
-  _DARWIN_C_SOURCE
-  _XOPEN_SOURCE=700
 )
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,8 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 target_compile_definitions(${PROJECT_NAME} PRIVATE
   _GNU_SOURCE
   _BSD_SOURCE
+  _NETBSD_SOURCE
+  _DARWIN_C_SOURCE
   _XOPEN_SOURCE=700
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,12 +49,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
   _GNU_SOURCE
+  _BSD_SOURCE
   _XOPEN_SOURCE=700
 )
-# _XOPEN_SOURCE hides BSD APIs on Darwin (initgroups).
-if(APPLE)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE _DARWIN_C_SOURCE)
-endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
   target_compile_options(${PROJECT_NAME} PRIVATE

--- a/src/ban.c
+++ b/src/ban.c
@@ -29,8 +29,6 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    */
 
-#define _POSIX_C_SOURCE 200809L
-
 #include "ban.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
I ran into the same problem mentioned in https://github.com/umurmur/umurmur/pull/250 but on OpenBSD. 
I think this is more portable, but I don't have a MacOS system to test unfortunately.