### PR TITLE
fix: Remove unused parameter in Sharedmemory_init()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -382,7 +382,7 @@ int main(int argc, char **argv)
 		Ban_init();
 
 #ifdef USE_SHAREDMEMORY_API
-    Sharedmemory_init( bindport, bindport6 );
+    Sharedmemory_init( bindport );
 #endif
 
 		/* SSL and scheduling is setup, we can drop privileges now */

--- a/src/main.c
+++ b/src/main.c
@@ -383,6 +383,7 @@ int main(int argc, char **argv)
 
 #ifdef USE_SHAREDMEMORY_API
   Sharedmemory_init( bindport );
+#endif
 
 	/* SSL and scheduling is setup, we can drop privileges now */
 	switch_user();

--- a/src/sharedmemory.c
+++ b/src/sharedmemory.c
@@ -4,7 +4,7 @@ static int shm_fd;
 static shm_t *shmptr = NULL;
 static char shm_file_name[128];
 
-void Sharedmemory_init( int bindport, int bindport6 )
+void Sharedmemory_init( int bindport )
 {
 
 	int server_max_clients = getIntConf(MAX_CLIENTS);

--- a/src/sharedmemory.h
+++ b/src/sharedmemory.h
@@ -15,7 +15,7 @@
 #include "channel.h"
 #include "sharedmemory_struct.h"
 
-void Sharedmemory_init( int bindport, int bindport6 );
+void Sharedmemory_init( int bindport );
 void Sharedmemory_update(void);
 void Sharedmemory_alivetick(void);
 void Sharedmemory_deinit(void);


### PR DESCRIPTION
Encountered `-Wunused-parameter` on Alpine:
```
#13 4.371 [ 94%] Building C object src/CMakeFiles/umurmurd.dir/sharedmemory.c.o
#13 4.520 /umurmur/src/sharedmemory.c: In function 'Sharedmemory_init':
#13 4.520 /umurmur/src/sharedmemory.c:7:43: warning: unused parameter 'bindport6' [-Wunused-parameter]
#13 4.520     7 | void Sharedmemory_init( int bindport, int bindport6 )
#13 4.520       |                                       ~~~~^~~~~~~~~
```