### PR TITLE
fix: Use snprintf in SSLi_init()

### DIFF
--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -269,7 +269,8 @@ void SSLi_init(void)
 		}
 		cipherstring = Memory_safeMalloc(1, cipherstringlen + 1);
 		for (i = 0; (cipher = sk_SSL_CIPHER_value(cipherlist_new, i)) != NULL; i++) {
-			offset += sprintf(cipherstring + offset, "%s:", SSL_CIPHER_get_name(cipher));
+			offset += snprintf(cipherstring + offset, cipherstringlen + 1 - offset,
+			                   "%s:", SSL_CIPHER_get_name(cipher));
 		}
 	}
 


### PR DESCRIPTION
```
ld: warning: ssli_openssl.c:272 (git/umurmur/src/ssli_openssl.c:272)(CMakeFiles/umurmurd.dir/ssli_openssl.c.o:(SSLi_init)): warning: sprintf() is often misused, please use snprintf()
```