### PR TITLE
fix: Add format attribute to log wrappers

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -42,18 +42,20 @@
 	} while (0)
 
 
-void logthis(const char *logstring, ...);
+#define PRINTF_LIKE(fmt, arg) __attribute__((__format__(__printf__, fmt, arg)))
+
+void logthis(const char *logstring, ...) PRINTF_LIKE(1, 2);
 
 #ifdef DEBUG
-void Log_debug(const char *logstring, ...);
+void Log_debug(const char *logstring, ...) PRINTF_LIKE(1, 2);
 #else
 #define Log_debug(_args_, ...) ((void)0)
 #endif
 
-void Log_warn(const char *logstring, ...);
-void Log_info(const char *logstring, ...);
-void Log_info_client(client_t *client, const char *logstring, ...);
-void Log_fatal(const char *logstring, ...) __attribute__((__noreturn__));
+void Log_warn(const char *logstring, ...) PRINTF_LIKE(1, 2);
+void Log_info(const char *logstring, ...) PRINTF_LIKE(1, 2);
+void Log_info_client(client_t *client, const char *logstring, ...) PRINTF_LIKE(2, 3);
+void Log_fatal(const char *logstring, ...) PRINTF_LIKE(1, 2) __attribute__((__noreturn__));
 
 void Log_init(bool_t terminal);
 bool_t Log_preflight(void);


### PR DESCRIPTION
Enable `printf` checking on the `Log_*` wrappers to appease `-Wformat=2`/`-Wmissing-format-attribute` on Clang.

```
[ 36%] Building C object src/CMakeFiles/umurmurd.dir/log.c.o
/home/trox/git/umurmur/src/log.c:229:30: warning: format string is not a string literal [-Wformat-nonliteral]
  229 |         vsnprintf(&buf[0], STRSIZE, logstring, argp);
      |                                     ^~~~~~~~~
/home/trox/git/umurmur/src/log.c:250:44: warning: format string is not a string literal [-Wformat-nonliteral]
  250 |         vsnprintf(&buf[offset], STRSIZE - offset, logstring, argp);
      |                                                   ^~~~~~~~~
/home/trox/git/umurmur/src/log.c:271:44: warning: format string is not a string literal [-Wformat-nonliteral]
  271 |         vsnprintf(&buf[offset], STRSIZE - offset, logstring, argp);
      |                                                   ^~~~~~~~~
/home/trox/git/umurmur/src/log.c:292:54: warning: format string is not a string literal [-Wformat-nonliteral]
  292 |         offset += vsnprintf(&buf[offset], STRSIZE - offset, logstring, argp);
      |                                                             ^~~~~~~~~
/home/trox/git/umurmur/src/log.c:343:44: warning: format string is not a string literal [-Wformat-nonliteral]
  343 |         vsnprintf(&buf[offset], STRSIZE - offset, logstring, argp);
      |                                                   ^~~~~~~~~
5 warnings generated.
```