### PR TITLE
build: generate config.h in build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-build-*
-config.h
-config.log
-config.status
+build*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,43 +1,35 @@
 set(SOURCE_FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/Mumble.pb-c.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/ban.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/channel.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/client.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/conf.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/crypt.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/log.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/main.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/memory.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/messagehandler.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/messages.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/pds.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/server.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/timer.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/util.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/voicetarget.c
-  )
+  Mumble.pb-c.c
+  ban.c
+  channel.c
+  client.c
+  conf.c
+  crypt.c
+  log.c
+  main.c
+  memory.c
+  messagehandler.c
+  messages.c
+  pds.c
+  server.c
+  timer.c
+  util.c
+  voicetarget.c
+)
 
 if(SSL MATCHES "mbedtls")
-  list(APPEND SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ssli_mbedtls.c)
+  list(APPEND SOURCE_FILES ssli_mbedtls.c)
 elseif(SSL MATCHES "gnutls")
-  list(APPEND SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ssli_gnutls.c)
+  list(APPEND SOURCE_FILES ssli_gnutls.c)
 else()
-  list(APPEND SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ssli_openssl.c)
-endif(SSL MATCHES "mbedtls")
+  list(APPEND SOURCE_FILES ssli_openssl.c)
+endif()
 
 if(USE_SHAREDMEMORY_API)
-  list(APPEND SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/sharedmemory.c)
+  list(APPEND SOURCE_FILES sharedmemory.c)
 endif(USE_SHAREDMEMORY_API)
 
-configure_file(config.h.in ${CMAKE_SOURCE_DIR}/src/config.h)
-
-include_directories(${LIBCONFIG_INCLUDE_DIR}
-                    ${PROTOBUFC_INCLUDE_DIR}
-                    ${SSLIMP_INCLUDE_DIR})
-
-link_directories(${LIBCONFIG_LIB_DIR}
-                 ${PROTOBUFC_LIB_DIR}
-                 ${SSLIMP_LIB_DIR})
+configure_file(config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
@@ -66,13 +58,21 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
   )
 endif()
 
-target_link_libraries(${PROJECT_NAME}
-                      ${LIBCONFIG_LIBRARIES}
-                      ${PROTOBUFC_LIBRARIES}
-                      ${SSLIMP_LIBRARIES}
-                      ${LIBRT}
-                      ${CRYPTO_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${LIBCONFIG_INCLUDE_DIR}
+  ${PROTOBUFC_INCLUDE_DIR}
+  ${SSLIMP_INCLUDE_DIR}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  ${LIBCONFIG_LIBRARIES}
+  ${PROTOBUFC_LIBRARIES}
+  ${SSLIMP_LIBRARIES}
+  ${LIBRT}
+  ${CRYPTO_LIBRARIES}
+)
 
 install(TARGETS ${PROJECT_NAME}
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )


### PR DESCRIPTION
Generate `config.h` inside build directory instead of source tree.
Also use scoped `target_` for `{include,link}_libraries`.

I'm not actually sure why `config.log` and `config.status` were being ignored. 
I've never seen those generated before, I may be wrong but I figure they're leftovers from build system of olde.