### PR TITLE
fix: Tidy extraneous newlines

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -146,18 +146,18 @@ static void openlogfile(const char *logfilename)
 
 	fd = openlogfd(logfilename);
 	if (fd < 0) {
-		Log_fatal("Failed to open log file '%s' for writing: %s\n", logfilename, strerror(errno));
+		Log_fatal("Failed to open log file '%s' for writing: %s", logfilename, strerror(errno));
 	}
 
 	logfile = fdopen(fd, "a");
 	if (logfile == NULL) {
 		close(fd);
-		Log_fatal("fdopen() failed for log file '%s': %s\n", logfilename, strerror(errno));
+		Log_fatal("fdopen() failed for log file '%s': %s", logfilename, strerror(errno));
 	}
 
 	/* Set the stream as line buffered */
 	if (setvbuf(logfile, NULL, _IOLBF, 0) < 0)
-		Log_fatal("setvbuf() failed: %s\n", strerror(errno));
+		Log_fatal("setvbuf() failed: %s", strerror(errno));
 
 	/* XXX - Is it neccessary/appropriate that logging to file is non-blocking?
 	 * If not, there's a risk that execution blocks, meaning that voice blocks

--- a/src/server.c
+++ b/src/server.c
@@ -181,7 +181,7 @@ void Server_runLoop(struct pollfd* pollfds)
 				fcntl(tcpfd, F_SETFL, O_NONBLOCK);
 				setsockopt(tcpfd, IPPROTO_TCP, TCP_NODELAY, (char *) &on, sizeof(int));
 				char *addressString = Util_addressToString(&remote);
-				Log_debug("Connection from %s port %d\n", addressString, Util_addressToPort(&remote));
+				Log_debug("Connection from %s port %d", addressString, Util_addressToPort(&remote));
 				free(addressString);
 				if (Client_add(tcpfd, &remote) < 0)
 					close(tcpfd);

--- a/src/sharedmemory.c
+++ b/src/sharedmemory.c
@@ -21,21 +21,21 @@ void Sharedmemory_init( int bindport )
 	shm_fd = shm_open( shm_file_name, O_CREAT | O_RDWR, 0660 );
 	if(shm_fd == -1)
 	{
-		Log_fatal( "SHM_API: Open failed:%s\n", strerror(errno));
+		Log_fatal("SHM_API: Open failed: %s", strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 
 	if( ftruncate( shm_fd, shmtotal_size ) == -1 )
 	{
 		Sharedmemory_deinit();
-		Log_fatal( "SHM_API: ftruncate : %s\n", strerror(errno));
+		Log_fatal("SHM_API: ftruncate: %s", strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 
 	shmptr = mmap( 0, shmtotal_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0 );
 	if (shmptr == MAP_FAILED)
 	{
-		Log_fatal( "SHM_API: mmap failed : %s\n", strerror(errno));
+		Log_fatal("SHM_API: mmap failed: %s", strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -404,7 +404,7 @@ static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
         X509_STORE_CTX_set_error(ctx, err);
     }
     if (!preverify_ok) {
-	    Log_warn("SSL: verify error:num=%d:%s:depth=%d:%s\n", err,
+	    Log_warn("SSL: verify error:num=%d:%s:depth=%d:%s", err,
 	             X509_verify_cert_error_string(err), depth, buf);
     }
     /*


### PR DESCRIPTION
`Log_` implementations already handle whether or not there should be a newline. 
```c
if (termprint)
	fprintf(stderr, "%s\n", buf);
else if (logfile)
	fprintf(logfile, "%s %s\n", timestring(), buf);
else
	syslog(LOG_DEBUG, "%s", buf);
```
These extra newlines cause doubles:
```
WARN: SSL: verify error:num=18:self-signed certificate:depth=0:/CN=Mumble User

INFO: User provided admin password - [2] unga@127.0.0.1:37974
```