### PR TITLE
feat: Remove legacy codec support

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -60,10 +60,6 @@ void Client_free(client_t *client);
 declare_list(clients);
 static int clientcount; /* = 0 */
 static int maxBandwidth;
-bool_t bOpus = true;
-
-int iCodecAlpha, iCodecBeta;
-bool_t bPreferAlpha;
 
 extern int* udpsocks;
 extern bool_t hasv4;
@@ -115,42 +111,6 @@ void Client_janitor(void)
 	Ban_pruneBanned();
 }
 
-void Client_codec_add(client_t *client, int codec)
-{
-	codec_t *cd = Memory_safeMalloc(1, sizeof(codec_t));
-	init_list_entry(&cd->node);
-	cd->codec = codec;
-	list_add_tail(&cd->node, &client->codecs);
-}
-
-void Client_codec_free(client_t *client)
-{
-	struct dlist *itr, *save;
-	list_iterate_safe(itr, save, &client->codecs) {
-		list_del(&list_get_entry(itr, codec_t, node)->node);
-		free(list_get_entry(itr, codec_t, node));
-	}
-}
-
-codec_t *Client_codec_iterate(client_t *client, codec_t **codec_itr)
-{
-	codec_t *cd = *codec_itr;
-
-	if (list_empty(&client->codecs))
-		return NULL;
-
-	if (cd == NULL) {
-		cd = list_get_entry(list_get_first(&client->codecs), codec_t, node);
-	} else {
-		if (list_get_next(&cd->node) == &client->codecs)
-			cd = NULL;
-		else
-			cd = list_get_entry(list_get_next(&cd->node), codec_t, node);
-	}
-	*codec_itr = cd;
-	return cd;
-}
-
 void Client_token_add(client_t *client, char *token_string)
 {
 	token_t *token;
@@ -193,111 +153,6 @@ void Client_token_free(client_t *client)
 		free(token);
 	}
 	client->tokencount = 0;
-}
-
-
-#define OPUS_WARN_USING "<strong>WARNING:</strong> Your client doesn't support the Opus codec the server is using, you won't be able to talk or hear anyone. Please upgrade your Mumble client."
-#define OPUS_WARN_SWITCHING "<strong>WARNING:</strong> Your client doesn't support the Opus codec the server is switching to, you won't be able to talk or hear anyone. Please upgrade your Mumble client."
-void recheckCodecVersions(client_t *connectingClient)
-{
-	client_t *client_itr = NULL;
-	int max = 0, version = 0, current_version = 0;
-	int users = 0, opus = 0;
-	message_t *sendmsg;
-	struct dlist codec_list, *itr, *save;
-	codec_t *codec_itr, *cd;
-	bool_t found;
-	bool_t enableOpus;
-
-	init_list_entry(&codec_list);
-
-	while (Client_iterate(&client_itr) != NULL) {
-		codec_itr = NULL;
-		if (client_itr->shutdown_wait)
-			continue;
-		if (client_itr->codec_count == 0 && !client_itr->bOpus)
-			continue;
-		while (Client_codec_iterate(client_itr, &codec_itr) != NULL) {
-			found = false;
-			list_iterate(itr, &codec_list) {
-				cd = list_get_entry(itr, codec_t, node);
-				if (cd->codec == codec_itr->codec) {
-					cd->count++;
-					found = true;
-				}
-			}
-			if (!found) {
-				cd = Memory_safeMalloc(1, sizeof(codec_t));
-				memset(cd, 0, sizeof(codec_t));
-				init_list_entry(&cd->node);
-				cd->codec = codec_itr->codec;
-				cd->count = 1;
-				list_add_tail(&cd->node, &codec_list);
-			}
-		}
-		users++;
-		if (client_itr->bOpus)
-			opus++;
-	}
-	if (users == 0)
-		return;
-
-	enableOpus = ((opus * 100 / users) >= getIntConf(OPUS_THRESHOLD));
-
-	list_iterate(itr, &codec_list) {
-		cd = list_get_entry(itr, codec_t, node);
-		if (cd->count > max) {
-			max = cd->count;
-			version = cd->codec;
-		}
-	}
-	list_iterate_safe(itr, save, &codec_list) {
-		list_del(&list_get_entry(itr, codec_t, node)->node);
-		free(list_get_entry(itr, codec_t, node));
-	}
-
-	current_version = bPreferAlpha ? iCodecAlpha : iCodecBeta;
-	if (current_version != version) {
-		// If we don't already use the compat bitstream version set
-		// it as alpha and announce it. If another codec now got the
-		// majority set it as the opposite of the currently valid bPreferAlpha
-		// and announce it.
-		if ((uint32_t)version == 0x8000000bU)
-			bPreferAlpha = true;
-		else
-			bPreferAlpha = !bPreferAlpha;
-
-		if (bPreferAlpha)
-			iCodecAlpha = version;
-		else
-			iCodecBeta = version;
-	} else if (bOpus && enableOpus) {
-		if (connectingClient && !connectingClient->bOpus)
-			Client_textmessage(connectingClient, OPUS_WARN_USING);
-		return;
-	}
-
-	sendmsg = Msg_create(CodecVersion);
-	sendmsg->payload.codecVersion->alpha = iCodecAlpha;
-	sendmsg->payload.codecVersion->beta = iCodecBeta;
-	sendmsg->payload.codecVersion->prefer_alpha = bPreferAlpha;
-	sendmsg->payload.codecVersion->has_opus = true;
-	sendmsg->payload.codecVersion->opus = enableOpus;
-
-	Client_send_message_except(NULL, sendmsg);
-
-	if (enableOpus && !bOpus) {
-		client_itr = NULL;
-		while (Client_iterate(&client_itr) != NULL) {
-			if ((client_itr->authenticated || client_itr == connectingClient) &&
-				!client_itr->bOpus) {
-				Client_textmessage(client_itr, OPUS_WARN_SWITCHING);
-			}
-		}
-		Log_info("OPUS codec %s", bOpus ? "enabled" : "disabled");
-	}
-
-	bOpus = enableOpus;
 }
 
 static int findFreeSessionId(void)
@@ -354,7 +209,6 @@ int Client_add(int fd, struct sockaddr_storage *remote)
 	init_list_entry(&newclient->chan_node);
 	init_list_entry(&newclient->node);
 	init_list_entry(&newclient->voicetargets);
-	init_list_entry(&newclient->codecs);
 	init_list_entry(&newclient->tokens);
 
 	list_add_tail(&newclient->node, &clients);
@@ -376,7 +230,6 @@ void Client_free(client_t *client)
 {
 	struct dlist *itr, *save;
 	message_t *sendmsg;
-	bool_t authenticatedLeft = client->authenticated;
 
 	if (client->authenticated) {
 		int leave_id;
@@ -394,7 +247,6 @@ void Client_free(client_t *client)
 		list_del(&list_get_entry(itr, message_t, node)->node);
 		Msg_free(list_get_entry(itr, message_t, node));
 	}
-	Client_codec_free(client);
 	Voicetarget_free_all(client);
 	Client_token_free(client);
 	CryptState_cleanup(&client->cryptState);
@@ -415,9 +267,6 @@ void Client_free(client_t *client)
 	if (client->context)
 		free(client->context);
 	free(client);
-
-	if (authenticatedLeft)
-		recheckCodecVersions(NULL); /* Can use better codec now? */
 }
 
 void Client_close(client_t *client)
@@ -870,12 +719,6 @@ int Client_read_udp(int udpsock)
 	char *clientAddressString = NULL;
 
 	switch (msgType) {
-		case UDPVoiceSpeex:
-		case UDPVoiceCELTAlpha:
-		case UDPVoiceCELTBeta:
-			if (bOpus)
-				break;
-			/* fall through */
 		case UDPVoiceOpus:
 			Client_voiceMsg(itr, buffer, len);
 			break;
@@ -914,8 +757,8 @@ int Client_voiceMsg(client_t *client, uint8_t *data, int len)
 	pds_t *pds = Pds_create(buffer + 1, UDP_PACKET_SIZE - 1);
 	unsigned int type = data[0] & 0xe0;
 	unsigned int target = data[0] & 0x1f;
-	unsigned int poslen, counter, size;
-	int offset, packetsize;
+	unsigned int poslen, size;
+	int packetsize;
 	voicetarget_t *vt;
 
 	channel_t *ch = client->channel;
@@ -932,16 +775,9 @@ int Client_voiceMsg(client_t *client, uint8_t *data, int len)
 	Timer_restart(&client->idleTime);
 	Timer_restart(&client->lastActivity);
 
-	counter = Pds_get_numval(pdi); /* step past session id */
-	if ((type >> 5) != UDPVoiceOpus) {
-		do {
-			counter = Pds_next8(pdi);
-			offset = Pds_skip(pdi, counter & 0x7f);
-		} while ((counter & 0x80) && offset > 0);
-	} else {
-		size = Pds_get_numval(pdi);
-		Pds_skip(pdi, size & 0x1fff);
-	}
+	Pds_get_numval(pdi); /* step past session id */
+	size = Pds_get_numval(pdi);
+	Pds_skip(pdi, size & 0x1fff);
 
 	poslen = pdi->maxsize - pdi->offset; /* For stripping of positional info */
 

--- a/src/client.h
+++ b/src/client.h
@@ -74,7 +74,7 @@ typedef struct {
 	int sessionId;
 	uint8_t key[KEY_LENGTH];
 	char *username;
-	bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording, bOpus;
+	bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording;
 	bool_t priority_speaker;
 	char *os, *release, *os_version;
 	uint32_t version;

--- a/src/client.h
+++ b/src/client.h
@@ -52,7 +52,6 @@
 #define BUFSIZE 8192
 #define UDP_BUFSIZE 512
 #define INACTIVITY_TIMEOUT 15 /* Seconds */
-#define MAX_CODECS 10
 #define MAX_TOKENSIZE 64
 #define MAX_TOKENS 32
 #define KEY_LENGTH sizeof(uint16_t) + 4 * sizeof(in_addr_t)
@@ -76,12 +75,9 @@ typedef struct {
 	uint8_t key[KEY_LENGTH];
 	char *username;
 	bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording, bOpus;
-	bool_t codec_recheck_pending;
 	bool_t priority_speaker;
 	char *os, *release, *os_version;
 	uint32_t version;
-	int codec_count;
-	struct dlist codecs;
 	int availableBandwidth;
 	etimer_t lastActivity, connectTime, idleTime;
 	struct dlist node;
@@ -99,11 +95,6 @@ typedef struct {
 	float UDPPingAvg, UDPPingVar, TCPPingAvg, TCPPingVar;
 	uint32_t UDPPackets, TCPPackets;
 } client_t;
-
-typedef struct {
-	int codec, count;
-	struct dlist node;
-} codec_t;
 
 typedef struct {
 	char *token;
@@ -127,10 +118,6 @@ int Client_send_message_except(client_t *client, message_t *msg);
 int Client_read_udp(int udpsock);
 void Client_disconnect_all();
 int Client_voiceMsg(client_t *client, uint8_t *data, int len);
-void recheckCodecVersions(client_t *connectingClient);
-void Client_codec_add(client_t *client, int codec);
-void Client_codec_free(client_t *client);
-codec_t *Client_codec_iterate(client_t *client, codec_t **codec_itr);
 void Client_textmessage(client_t *client, char *text);
 bool_t Client_token_match(client_t *client, char const *str);
 void Client_token_free(client_t *client);

--- a/src/conf.c
+++ b/src/conf.c
@@ -46,7 +46,6 @@ static config_t configuration;
 #define DEFAULT_MAX_BANDWIDTH 48000
 #define DEFAULT_BINDPORT 64738
 #define DEFAULT_BAN_LENGTH (60*60)
-#define DEFAULT_OPUS_THRESHOLD 100
 
 const char defaultconfig[] = DEFAULT_CONFIG;
 
@@ -281,14 +280,6 @@ int getIntConf(param_t param)
 			setting = config_lookup(&configuration, "max_users");
 			if (!setting)
 				return DEFAULT_MAX_CLIENTS;
-			else {
-				return config_setting_get_int(setting);
-			}
-			break;
-		case OPUS_THRESHOLD:
-			setting = config_lookup(&configuration, "opus_threshold");
-			if (!setting)
-				return DEFAULT_OPUS_THRESHOLD;
 			else {
 				return config_setting_get_int(setting);
 			}

--- a/src/messagehandler.c
+++ b/src/messagehandler.c
@@ -47,14 +47,10 @@
 #define MAX_TEXT 512
 #define MAX_USERNAME 128
 
-#define NO_CELT_MESSAGE "<strong>WARNING:</strong> Your client doesn't support the CELT codec, you won't be able to talk to or hear most clients. Please make sure your client was built with CELT support."
+#define OPUS_CLIENT_UNSUPPORTED "<strong>WARNING:</strong> Your client doesn't support the Opus codec the server is using, you won't be able to talk or hear anyone. Please upgrade your Mumble client."
 
 
 extern channel_t *defaultChan;
-extern int iCodecAlpha, iCodecBeta;
-extern bool_t bPreferAlpha, bOpus;
-
-static bool_t fake_celt_support;
 
 static void sendServerReject(client_t *client, const char *reason, MumbleProto__Reject__RejectType type)
 {
@@ -106,12 +102,6 @@ void Mh_handle_message(client_t *client, message_t *msg)
 	if (!client->authenticated && !(msg->messageType == Authenticate ||
 									msg->messageType == Version)) {
 		goto out;
-	}
-
-	if (client->codec_recheck_pending && client->authenticated &&
-	    msg->messageType != Authenticate) {
-		client->codec_recheck_pending = false;
-		recheckCodecVersions(client);
 	}
 
 	switch (msg->messageType) {
@@ -222,40 +212,17 @@ void Mh_handle_message(client_t *client, message_t *msg)
 		client->authenticated = true;
 
 		/* Codec version */
-		Log_debug("Client %d has %d CELT codecs", client->sessionId,
-				  msg->payload.authenticate->n_celt_versions);
-		if (msg->payload.authenticate->n_celt_versions > 0) {
-			int i;
-			codec_t *codec_itr;
-			client->codec_count = msg->payload.authenticate->n_celt_versions;
-
-			for (i = 0; i < client->codec_count; i++)
-			Client_codec_add(client, msg->payload.authenticate->celt_versions[i]);
-			codec_itr = NULL;
-			while (Client_codec_iterate(client, &codec_itr) != NULL)
-				Log_debug("Client %d CELT codec ver 0x%x", client->sessionId, codec_itr->codec);
-
-		} else {
-			Client_codec_add(client, (int32_t)0x8000000b);
-			client->codec_count = 1;
-			fake_celt_support = true;
-		}
 		if (msg->payload.authenticate->opus)
 			client->bOpus = true;
 
-		client->codec_recheck_pending = true;
-
 		sendmsg = Msg_create(CodecVersion);
-		sendmsg->payload.codecVersion->alpha = iCodecAlpha;
-		sendmsg->payload.codecVersion->beta = iCodecBeta;
-		sendmsg->payload.codecVersion->prefer_alpha = bPreferAlpha;
 		sendmsg->payload.codecVersion->has_opus = true;
-		sendmsg->payload.codecVersion->opus = bOpus;
+		sendmsg->payload.codecVersion->opus = true;
 		Client_send_message(client, sendmsg);
 
-		if (!bOpus && client->bOpus && fake_celt_support) {
-			Client_textmessage(client, NO_CELT_MESSAGE);
-		}
+		if (!client->bOpus)
+			sendServerReject(client, OPUS_CLIENT_UNSUPPORTED,
+			    MUMBLE_PROTO__REJECT__REJECT_TYPE__None);
 
 		/* Iterate channels and send channel info */
 		ch_itr = NULL;
@@ -813,8 +780,6 @@ void Mh_handle_message(client_t *client, message_t *msg)
 	case UserStats:
 	{
 		client_t *target = NULL;
-		codec_t *codec_itr = NULL;
-		int i;
 		bool_t details = true;
 
 		if (msg->payload.userStats->has_stats_only)
@@ -879,13 +844,6 @@ void Mh_handle_message(client_t *client, message_t *msg)
 				sendmsg->payload.userStats->version->os = strdup(target->os);
 			if (target->os_version)
 				sendmsg->payload.userStats->version->os_version = strdup(target->os_version);
-
-			sendmsg->payload.userStats->n_celt_versions = target->codec_count;
-			sendmsg->payload.userStats->celt_versions
-				= Memory_safeMalloc(target->codec_count, sizeof(int32_t));
-			i = 0;
-			while (Client_codec_iterate(target, &codec_itr) != NULL)
-				sendmsg->payload.userStats->celt_versions[i++] = codec_itr->codec;
 
 			sendmsg->payload.userStats->has_opus = true;
 			sendmsg->payload.userStats->opus = target->bOpus;

--- a/src/messagehandler.c
+++ b/src/messagehandler.c
@@ -47,7 +47,7 @@
 #define MAX_TEXT 512
 #define MAX_USERNAME 128
 
-#define OPUS_CLIENT_UNSUPPORTED "<strong>WARNING:</strong> Your client doesn't support the Opus codec the server is using, you won't be able to talk or hear anyone. Please upgrade your Mumble client."
+#define OPUS_CLIENT_UNSUPPORTED "Your client does not support Opus. Please upgrade your Mumble client."
 
 
 extern channel_t *defaultChan;
@@ -131,6 +131,12 @@ void Mh_handle_message(client_t *client, message_t *msg)
 			break;
 		}
 
+		if (!msg->payload.authenticate->opus) {
+			sendServerReject(client, OPUS_CLIENT_UNSUPPORTED,
+			    MUMBLE_PROTO__REJECT__REJECT_TYPE__None);
+			goto disconnect;
+		}
+
 		if (SSLi_getSHA1Hash(client->ssl, client->hash) && Ban_isBanned(client)) {
 			char hexhash[41];
 			SSLi_hash2hex(client->hash, hexhash);
@@ -211,18 +217,10 @@ void Mh_handle_message(client_t *client, message_t *msg)
 
 		client->authenticated = true;
 
-		/* Codec version */
-		if (msg->payload.authenticate->opus)
-			client->bOpus = true;
-
 		sendmsg = Msg_create(CodecVersion);
 		sendmsg->payload.codecVersion->has_opus = true;
 		sendmsg->payload.codecVersion->opus = true;
 		Client_send_message(client, sendmsg);
-
-		if (!client->bOpus)
-			sendServerReject(client, OPUS_CLIENT_UNSUPPORTED,
-			    MUMBLE_PROTO__REJECT__REJECT_TYPE__None);
 
 		/* Iterate channels and send channel info */
 		ch_itr = NULL;
@@ -846,7 +844,7 @@ void Mh_handle_message(client_t *client, message_t *msg)
 				sendmsg->payload.userStats->version->os_version = strdup(target->os_version);
 
 			sendmsg->payload.userStats->has_opus = true;
-			sendmsg->payload.userStats->opus = target->bOpus;
+			sendmsg->payload.userStats->opus = true;
 
 			/* Address */
 			if (getBoolConf(SHOW_ADDRESSES)) {

--- a/src/messages.c
+++ b/src/messages.c
@@ -612,8 +612,6 @@ void Msg_free(message_t *msg)
 
 				free(msg->payload.userStats->version);
 			}
-			if (msg->payload.userStats->celt_versions)
-				free(msg->payload.userStats->celt_versions);
 			if (msg->payload.userStats->certificates) {
 				if (msg->payload.userStats->certificates->data)
 					free(msg->payload.userStats->certificates->data);

--- a/src/sharedmemory.c
+++ b/src/sharedmemory.c
@@ -88,7 +88,7 @@ void Sharedmemory_update(void)
 				shmptr->client[cc].bUDP  = client_itr->bUDP;
 				shmptr->client[cc].deaf  = client_itr->deaf;
 				shmptr->client[cc].mute  = client_itr->mute;
-				shmptr->client[cc].bOpus  = client_itr->bOpus;
+				shmptr->client[cc].bOpus  = true;
 				shmptr->client[cc].self_deaf  = client_itr->self_deaf;
 				shmptr->client[cc].self_mute  = client_itr->self_mute;
 				shmptr->client[cc].recording  = client_itr->recording;

--- a/src/sharedmemory_struct.h
+++ b/src/sharedmemory_struct.h
@@ -12,7 +12,7 @@ typedef struct
   char channel[121];
   char os[121], release[121], os_version[121];
   int tcp_port, udp_port;
-  bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording;
+  bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording, bOpus;
   int availableBandwidth;
   uint32_t online_secs, idle_secs;
   uint8_t hash[20];

--- a/src/sharedmemory_struct.h
+++ b/src/sharedmemory_struct.h
@@ -12,7 +12,7 @@ typedef struct
   char channel[121];
   char os[121], release[121], os_version[121];
   int tcp_port, udp_port;
-  bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording, bOpus;
+  bool_t bUDP, authenticated, deaf, mute, self_deaf, self_mute, recording;
   int availableBandwidth;
   uint32_t online_secs, idle_secs;
   uint8_t hash[20];

--- a/umurmur.conf.example
+++ b/umurmur.conf.example
@@ -9,7 +9,6 @@ password = "";
 # banfile = "banfile.txt";   # File to save bans to. Default is to not save bans to file.
 # sync_banfile = false;      # Keep banfile synced. Default is false, which means it is saved to at shutdown only.
 # allow_textmessage = true;  # Default is true
-# opus_threshold = 100;      # Percentage of users supporting Opus codec for it to be chosen. Default is 100.
 # show_addresses = true;     # Whether to show client's IP addresses under user information
 max_users = 10;
 


### PR DESCRIPTION
Remove all code related to handling clients who don't play with Opus. If a client reports not having Opus support, reject them. There is no practical reason to use another codec.

Mumble >= 1.2.4 supports Opus [1]
Mumble >= 1.5.517 removed legacy codecs [2]

[1] https://www.mumble.info/blog/mumble-1.2.4-released/
[2] https://www.mumble.info/blog/mumble-1.5.517-rc/