### PR TITLE
feat: Always make realtime switch available

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -41,12 +41,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#ifdef _POSIX_PRIORITY_SCHEDULING
-#if (_POSIX_PRIORITY_SCHEDULING > 0)
-#define POSIX_PRIORITY_SCHEDULING
 #include <sched.h>
-#endif
-#endif
 #include "server.h"
 #include "ssl.h"
 #include "channel.h"
@@ -231,7 +226,6 @@ void daemonize(void)
 		Log_fatal("chdir: %s", strerror(errno));
 }
 
-#ifdef POSIX_PRIORITY_SCHEDULING
 void setscheduler(void)
 {
 	int rc;
@@ -243,34 +237,29 @@ void setscheduler(void)
 	if (rc < 0)
 		Log_warn("Failed to set scheduler: %s", strerror(errno));
 }
-#endif
 
 void printhelp(void)
 {
 	printf("uMurmur version %s ('%s'). Mumble protocol %d.%d.%d\n", UMURMUR_VERSION,
 		UMURMUR_CODENAME, PROTVER_MAJOR, PROTVER_MINOR, PROTVER_PATCH);
-	printf("Usage: umurmurd [-d] [-r] [-h] [-p <pidfile>] [-t] [-c <conf file>] [-a <addr>] [-b <port>]\n");
+	printf("Usage: umurmurd [-dhrt] [-A <address>] [-a <address>] [-B <port>] [-b <port>] [-c <conf file>] [-p <pidfile>]\n");
 	printf("       -d             - Do not daemonize - run in foreground.\n");
-#ifdef POSIX_PRIORITY_SCHEDULING
-	printf("       -r             - Run with realtime priority\n");
-#endif
-	printf("       -p <pidfile>   - Write PID to this file\n");
-	printf("       -c <conf file> - Specify configuration file (default %s)\n", DEFAULT_CONFIG);
-	printf("       -t             - Test config. Error message to stderr + non-zero exit code on error\n");
-	printf("       -a <address>   - Bind to IP address\n");
-	printf("       -A <address>   - Bind to IPv6 address\n");
-	printf("       -b <port>      - Bind to port\n");
-	printf("       -B <port>      - Bind to port (IPv6)\n");
 	printf("       -h             - Print this help\n");
+	printf("       -r             - Run with realtime priority\n");
+	printf("       -t             - Test config. Error message to stderr + non-zero exit code on error\n");
+	printf("       -A <address>   - Bind to IPv6 address\n");
+	printf("       -a <address>   - Bind to IP address\n");
+	printf("       -B <port>      - Bind to port (IPv6)\n");
+	printf("       -b <port>      - Bind to port\n");
+	printf("       -c <conf file> - Specify configuration file (default %s)\n", DEFAULT_CONFIG);
+	printf("       -p <pidfile>   - Write PID to this file\n");
 	exit(0);
 }
 
 int main(int argc, char **argv)
 {
 	bool_t nodaemon = false;
-#ifdef POSIX_PRIORITY_SCHEDULING
 	bool_t realtime = false;
-#endif
 	bool_t testconfig = false;
 #ifdef __OpenBSD__
 	bool_t needs_filesystem = false;
@@ -281,17 +270,19 @@ int main(int argc, char **argv)
 	struct utsname utsbuf;
 
 	/* Arguments */
-#ifdef POSIX_PRIORITY_SCHEDULING
-	while ((c = getopt(argc, argv, "drp:c:a:A:b:B:ht")) != EOF) {
-#else
-	while ((c = getopt(argc, argv, "dp:c:a:A:b:B:ht")) != EOF) {
-#endif
+	while ((c = getopt(argc, argv, "dhrta:A:b:B:c:p:")) != EOF) {
 		switch(c) {
-			case 'c':
-				conffile = optarg;
+			case 'd':
+				nodaemon = true;
 				break;
-			case 'p':
-				pidfile = optarg;
+			case 'h':
+				printhelp();
+				break;
+			case 'r':
+				realtime = true;
+				break;
+			case 't':
+				testconfig = true;
 				break;
 			case 'a':
 				bindaddr = optarg;
@@ -305,20 +296,12 @@ int main(int argc, char **argv)
 			case 'B':
 				bindport6 = atoi(optarg);
 				break;
-			case 'd':
-				nodaemon = true;
+			case 'c':
+				conffile = optarg;
 				break;
-			case 'h':
-				printhelp();
+			case 'p':
+				pidfile = optarg;
 				break;
-			case 't':
-				testconfig = true;
-				break;
-#ifdef POSIX_PRIORITY_SCHEDULING
-			case 'r':
-				realtime = true;
-				break;
-#endif
 			default:
 				fprintf(stderr, "Unrecognized option\n");
 				printhelp();
@@ -350,12 +333,10 @@ int main(int argc, char **argv)
 	}
 	else Log_init(true);
 
-#ifdef POSIX_PRIORITY_SCHEDULING
 	/* Set the scheduling policy, has to be called after daemonizing
 	 * but before we drop privileges */
 	if (realtime)
 		setscheduler();
-#endif
 	signal(SIGCHLD, SIG_IGN); /* ignore child */
 	signal(SIGTSTP, SIG_IGN); /* ignore tty signals */
 	signal(SIGTTOU, SIG_IGN);


### PR DESCRIPTION
Considering realtime is POSIX.1-2001 there's no reason to gate it at compile time.
    
Also sort the command line arguments.

Fixes #258