### PR TITLE
test: Add basic testing helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,12 @@ check_function_exists(strlcpy HAVE_STRLCPY)
 
 add_subdirectory(src)
 
+enable_testing()
+add_test(NAME umurmurd-help COMMAND $<TARGET_FILE:umurmurd> -h)
+set_tests_properties(umurmurd-help PROPERTIES
+  PASS_REGULAR_EXPRESSION "Usage: umurmurd"
+)
+
 install(
   FILES "umurmur.conf.example"
   DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/umurmur"

--- a/hack/make-all.sh
+++ b/hack/make-all.sh
@@ -13,7 +13,6 @@ for S in mbedtls openssl gnutls; do
 		-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
 		-DCMAKE_RULE_MESSAGES=ON \
 		-DUSE_SHAREDMEMORY_API=${SHMEM} \
-		-DSSL=${SSL} \
 		&& \
 	cmake --build build-${S} && \
 	ctest --test-dir build-${S} --output-on-failure -V && \

--- a/hack/make-all.sh
+++ b/hack/make-all.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env zsh
+
+# Quick-and-dirty build against all available SSL libraries
+
+export CODE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")/.." && pwd -P)"
+export BUILD_TYPE=debug
+export SHMEM=true
+
+for S in mbedtls openssl gnutls; do
+	cd ${CODE_DIR}
+	rm -rf build-${S} && \
+	cmake -Bbuild-${S} -DSSL=${S} \
+		-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+		-DCMAKE_RULE_MESSAGES=ON \
+		-DUSE_SHAREDMEMORY_API=${SHMEM} \
+		-DSSL=${SSL} \
+		&& \
+	cmake --build build-${S} && \
+	ctest --test-dir build-${S} --output-on-failure -V && \
+	cd -
+done

--- a/hack/remote-build.sh
+++ b/hack/remote-build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env zsh
+
+# Quick-and-dirty push to VMs for testing builds
+
+[[ -z $1 ]] && echo "Usage: $0 host1 ..."
+
+CODE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")/.." && pwd -P)"
+
+for host in $@ ; do
+	rsync -az --delete --exclude .git ${CODE_DIR} $host:git/
+done
+
+for host in $@ ; do
+	echo -e "#\n# $host\n#"
+	ssh $host 'cd ~/git/umurmur && ./hack/make-all.sh'
+done
+
+for host in $@ ; do
+	echo $host
+	ssh $host 'ls -l ~/git/umurmur/build-*/src/umurmurd'
+done


### PR DESCRIPTION
Introduce some basic "junk-drawer" tests, and start exploring CTest framework for regression testing. These were set up to validate compilation across various POSIX-compliant OSs that don't support the Docker build checks.