### PR TITLE
fix: Memory leak in OpenSSL X509 handling

### DIFF
--- a/src/ssli_openssl.c
+++ b/src/ssli_openssl.c
@@ -353,6 +353,7 @@ bool_t SSLi_getSHA1Hash(SSL_handle_t *ssl, uint8_t *hash)
 
 	SHA1(buf, len, hash);
 	free(buf);
+	X509_free(x509);
 	return true;
 }
 


### PR DESCRIPTION
Before:
```
==3057068==
==3057068== HEAP SUMMARY:
==3057068==     in use at exit: 5,145 bytes in 72 blocks
==3057068==   total heap usage: 18,822 allocs, 18,750 frees, 1,619,465 bytes allocated
==3057068==
==3057068== 5,145 (384 direct, 4,761 indirect) bytes in 1 blocks are definitely lost in loss record 53 of 53
==3057068==    at 0x48C28A8: malloc (vg_replace_malloc.c:446)
==3057068==    by 0x4B8E10E: CRYPTO_malloc (mem.c:214)
==3057068==    by 0x4B8E1B5: CRYPTO_zalloc (mem.c:226)
==3057068==    by 0x4A61291: asn1_item_embed_new.lto_priv.0 (tasn_new.c:135)
==3057068==    by 0x4A61447: ASN1_item_new_ex (tasn_new.c:41)
==3057068==    by 0x4C4EB0B: X509_new_ex (x_x509.c:159)
==3057068==    by 0x49B21CF: tls_process_client_certificate (statem_srvr.c:3864)
==3057068==    by 0x499741B: read_state_machine (statem.c:663)
==3057068==    by 0x499A6DD: state_machine (statem.c:481)
==3057068==    by 0x401BCD7: SSLi_nonblockaccept (ssli_openssl.c:307)
==3057068==    by 0x400DF94: Client_read (client.c:321)
==3057068==    by 0x400DEE6: Client_read_fd (client.c:299)
==3057068==
==3057068== LEAK SUMMARY:
==3057068==    definitely lost: 384 bytes in 1 blocks
==3057068==    indirectly lost: 4,761 bytes in 71 blocks
==3057068==      possibly lost: 0 bytes in 0 blocks
==3057068==    still reachable: 0 bytes in 0 blocks
==3057068==         suppressed: 0 bytes in 0 blocks
```

After:
```
==3121532==
==3121532== HEAP SUMMARY:
==3121532==     in use at exit: 0 bytes in 0 blocks
==3121532==   total heap usage: 22,446 allocs, 22,446 frees, 2,109,988 bytes allocated
==3121532==
==3121532== All heap blocks were freed -- no leaks are possible
==3121532==
```