### PR TITLE
ci: Expand CI for nightly checks

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,22 +9,33 @@ on:
       - cmake/**
       - CMakeLists.txt
       - Dockerfile.*
+      - .github/workflows/docker.yaml
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        distro: [ alpine, debian ]
-        ssl: [ gnutls, mbedtls, openssl ]  # Supported TLS libraries
+        config:
+          - { family: alpine, base: alpine:3.22 }
+          - { family: alpine, base: alpine:3.23 }
+          - { family: alpine, base: alpine:3.24 }
+          - { family: alpine, base: alpine:latest }
+          - { family: debian, base: debian:trixie-slim }
+          - { family: debian, base: debian:unstable-slim }
+        ssl: [gnutls, mbedtls, openssl]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Containerized build
         run: |
-          docker build -f Dockerfile.${{ matrix.distro }} --build-arg SSL=${{ matrix.ssl }} .
-
+          docker build -f Dockerfile.${{ matrix.config.family }} \
+            --build-arg BASE_IMAGE=${{ matrix.config.base }} \
+            --build-arg SSL=${{ matrix.ssl }} .

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -18,14 +18,7 @@ RUN \
 		protobuf-c-dev ; \
 	[ "${SSL}" == "gnutls" ] && apk add gnutls-dev ; \
 	[ "${SSL}" == "openssl" ] && apk add openssl-dev ; \
-	if [ "${SSL}" == "mbedtls" ] ; then \
-		curl -o mbedtls.tar.bz2 -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.5/mbedtls-3.6.5.tar.bz2 && \
-		tar -jxvf mbedtls.tar.bz2 && \
-		cd mbedtls-* && \
-		cmake -Bbuild -H. -DENABLE_TESTING=OFF && \
-		cmake --build build && \
-		cmake --install build ; \
-	fi ; \
+	[ "${SSL}" == "mbedtls" ] && apk add mbedtls-dev ; \
 	echo "Installed deps for building against ${SSL}"
 
 WORKDIR /umurmur
@@ -56,6 +49,7 @@ RUN \
 		protobuf-c ; \
 	[ "${SSL}" == "gnutls" ] && apk add gnutls; \
 	[ "${SSL}" == "openssl" ] && apk add openssl ; \
+	[ "${SSL}" == "mbedtls" ] && apk add mbedtls ; \
 	rm -rf /var/cache/apk/* ; \
 	mkdir /etc/umurmur
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,7 @@
+ARG BASE_IMAGE=alpine:latest
+
 # Stage 1: Build
-FROM alpine:3.23 AS build
+FROM ${BASE_IMAGE} AS build
 
 ARG SSL=openssl
 ARG BUILD_TYPE=debug
@@ -33,7 +35,6 @@ COPY cmake cmake
 COPY umurmur.conf.example .
 COPY src src
 
-# Build against both OpenSSL and Mbed TLS
 RUN \
 	cmake -Bbuild-${SSL} -H. \
 		-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
@@ -43,8 +44,8 @@ RUN \
 	cmake --build build-${SSL} && \
 	cmake --install build-${SSL}
 
-# # Stage 2: Runtime
-FROM alpine:3.23
+# Stage 2: Runtime
+FROM ${BASE_IMAGE}
 
 ARG SSL=openssl
 
@@ -58,8 +59,6 @@ RUN \
 	rm -rf /var/cache/apk/* ; \
 	mkdir /etc/umurmur
 
-
-# Copy the compiled binary from the build stage, default to OpenSSL
 COPY --from=build /usr/local/bin/umurmurd /usr/local/bin/
 COPY --from=build /umurmur/umurmur.conf.example /usr/local/etc/umurmur/umurmur.conf
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,5 +1,7 @@
+ARG BASE_IMAGE=debian:unstable
+
 # Stage 1: Build
-FROM debian:trixie-slim AS build
+FROM ${BASE_IMAGE} AS build
 
 ARG SSL=openssl
 ARG BUILD_TYPE=debug
@@ -9,25 +11,20 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN \
 	apt-get update && \
 	apt-get install -qq -y --no-install-recommends \
-		curl \
-		git \
-		ca-certificates \
 		build-essential \
+		ca-certificates \
 		cmake \
+		git \
 		libconfig-dev \
-		libprotobuf-c-dev
+		libprotobuf-c-dev \
+		pkg-config
 
 RUN \
 	if test "${SSL}" = "gnutls" ; then \
 		apt-get install -qq -y --no-install-recommends libgnutls28-dev; \
 	fi && \
 	if test "${SSL}" = "mbedtls" ; then \
-		curl -o mbedtls.tar.bz2 -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.5/mbedtls-3.6.5.tar.bz2 && \
-		tar -jxvf mbedtls.tar.bz2 && \
-		cd mbedtls-* && \
-		cmake -Bbuild -H. -DENABLE_TESTING=OFF && \
-		cmake --build build && \
-		cmake --install build; \
+		apt-get install -qq -y --no-install-recommends libmbedtls-dev; \
 	fi && \
 	if test "${SSL}" = "openssl" ; then \
 		apt-get install -qq -y --no-install-recommends libssl-dev ; \
@@ -41,7 +38,6 @@ COPY cmake cmake
 COPY umurmur.conf.example .
 COPY src src
 
-# Build against both OpenSSL and Mbed TLS
 RUN \
 	cmake -Bbuild-${SSL} -H. \
 		-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
@@ -52,29 +48,32 @@ RUN \
 	cmake --install build-${SSL}
 
 # Stage 2: Runtime
-FROM debian:trixie-slim
+FROM ${BASE_IMAGE}
 
 ARG SSL=openssl
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
 	apt-get update && \
 	apt-get install -qq -y --no-install-recommends \
-		libconfig11 \
+		libconfig-dev \
 		libprotobuf-c1 && \
 	if test "${SSL}" = "gnutls" ; then \
-		apt-get install -qq -y --no-install-recommends libgnutls30 ; \
+		apt-get install -qq -y --no-install-recommends libgnutls28-dev ; \
+	fi && \
+	if test "${SSL}" = "mbedtls" ; then \
+		apt-get install -qq -y --no-install-recommends \
+			libmbedtls-dev ; \
 	fi && \
 	if test "${SSL}" = "openssl" ; then \
-		apt-get install -qq -y --no-install-recommends libssl3 ; \
+		apt-get install -qq -y --no-install-recommends libssl-dev ; \
 	fi && \
 	rm -rf /var/lib/apt/lists/* && \
 	mkdir /etc/umurmur
 
-# Copy the compiled binary from the build stage, default to OpenSSL
 COPY --from=build /usr/local/bin/umurmurd /usr/local/bin/
 COPY --from=build /umurmur/umurmur.conf.example /usr/local/etc/umurmur/umurmur.conf
 
 EXPOSE 64738
 
 ENTRYPOINT ["/usr/local/bin/umurmurd", "-d"]
-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 # Test compilation against some popular Linux distros
 #   docker compose --profile stable build
-#   docker compose --profile rolling build
+#   docker compose --profile latest build
 
 x-umurmur: &umurmur
   depends_on:
@@ -29,7 +29,7 @@ services:
 
   alpine-stable-gnutls:
     <<: *umurmur
-    profiles: [stable]
+    profiles: [alpine, stable]
     build:
       context: .
       dockerfile: Dockerfile.alpine
@@ -39,7 +39,7 @@ services:
 
   alpine-stable-mbedtls:
     <<: *umurmur
-    profiles: [stable]
+    profiles: [alpine, stable]
     build:
       context: .
       dockerfile: Dockerfile.alpine
@@ -49,7 +49,7 @@ services:
 
   alpine-stable-openssl:
     <<: *umurmur
-    profiles: [stable]
+    profiles: [alpine, stable]
     build:
       context: .
       dockerfile: Dockerfile.alpine
@@ -59,7 +59,7 @@ services:
 
   debian-stable-gnutls:
     <<: *umurmur
-    profiles: [stable]
+    profiles: [debian, stable]
     build:
       context: .
       dockerfile: Dockerfile.debian
@@ -69,7 +69,7 @@ services:
 
   debian-stable-mbedtls:
     <<: *umurmur
-    profiles: [stable]
+    profiles: [debian, stable]
     build:
       context: .
       dockerfile: Dockerfile.debian
@@ -79,7 +79,7 @@ services:
 
   debian-stable-openssl:
     <<: *umurmur
-    profiles: [stable]
+    profiles: [debian, stable]
     build:
       context: .
       dockerfile: Dockerfile.debian
@@ -89,7 +89,7 @@ services:
 
   alpine-latest-gnutls:
     <<: *umurmur
-    profiles: [rolling]
+    profiles: [alpine, latest]
     build:
       context: .
       dockerfile: Dockerfile.alpine
@@ -99,7 +99,7 @@ services:
 
   alpine-latest-mbedtls:
     <<: *umurmur
-    profiles: [rolling]
+    profiles: [alpine, latest]
     build:
       context: .
       dockerfile: Dockerfile.alpine
@@ -109,7 +109,7 @@ services:
 
   alpine-latest-openssl:
     <<: *umurmur
-    profiles: [rolling]
+    profiles: [alpine, latest]
     build:
       context: .
       dockerfile: Dockerfile.alpine
@@ -119,7 +119,7 @@ services:
 
   debian-unstable-gnutls:
     <<: *umurmur
-    profiles: [rolling]
+    profiles: [debian, latest]
     build:
       context: .
       dockerfile: Dockerfile.debian
@@ -129,7 +129,7 @@ services:
 
   debian-unstable-mbedtls:
     <<: *umurmur
-    profiles: [rolling]
+    profiles: [debian, latest]
     build:
       context: .
       dockerfile: Dockerfile.debian
@@ -139,7 +139,7 @@ services:
 
   debian-unstable-openssl:
     <<: *umurmur
-    profiles: [rolling]
+    profiles: [debian, latest]
     build:
       context: .
       dockerfile: Dockerfile.debian

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,14 @@
+# Test compilation against some popular Linux distros
+#   docker compose --profile stable build
+#   docker compose --profile rolling build
+
+x-umurmur: &umurmur
+  depends_on:
+    cert-init:
+      condition: service_completed_successfully
+  volumes:
+    - umurmur-certs:/etc/umurmur:ro
+
 services:
   cert-init:
     image: alpine:latest
@@ -16,78 +27,125 @@ services:
       - umurmur-certs:/certs
     restart: "no"
 
-  debian-gnutls:
+  alpine-stable-gnutls:
+    <<: *umurmur
+    profiles: [stable]
     build:
       context: .
-      args:
-        - SSL=gnutls
-      dockerfile: Dockerfile.debian
-    depends_on:
-      cert-init:
-        condition: service_completed_successfully
-    volumes:
-      - umurmur-certs:/etc/umurmur:ro
-
-  debian-mbedtls:
-    build:
-      context: .
-      args:
-        - SSL=mbedtls
-      dockerfile: Dockerfile.debian
-    depends_on:
-      cert-init:
-        condition: service_completed_successfully
-    volumes:
-      - umurmur-certs:/etc/umurmur:ro
-
-  debian-openssl:
-    build:
-      context: .
-      args:
-        - SSL=openssl
-      dockerfile: Dockerfile.debian
-    depends_on:
-      cert-init:
-        condition: service_completed_successfully
-    volumes:
-      - umurmur-certs:/etc/umurmur:ro
-
-  alpine-gnutls:
-    build:
-      context: .
-      args:
-        - SSL=gnutls
       dockerfile: Dockerfile.alpine
-    depends_on:
-      cert-init:
-        condition: service_completed_successfully
-    volumes:
-      - umurmur-certs:/etc/umurmur:ro
+      args:
+        BASE_IMAGE: alpine:3.24
+        SSL: gnutls
 
-  alpine-mbedtls:
+  alpine-stable-mbedtls:
+    <<: *umurmur
+    profiles: [stable]
     build:
       context: .
-      args:
-        - SSL=mbedtls
       dockerfile: Dockerfile.alpine
-    depends_on:
-      cert-init:
-        condition: service_completed_successfully
-    volumes:
-      - umurmur-certs:/etc/umurmur:ro
+      args:
+        BASE_IMAGE: alpine:3.24
+        SSL: mbedtls
 
-  alpine-openssl:
+  alpine-stable-openssl:
+    <<: *umurmur
+    profiles: [stable]
     build:
       context: .
-      args:
-        - SSL=openssl
       dockerfile: Dockerfile.alpine
-    depends_on:
-      cert-init:
-        condition: service_completed_successfully
-    volumes:
-      - umurmur-certs:/etc/umurmur:ro
+      args:
+        BASE_IMAGE: alpine:3.24
+        SSL: openssl
+
+  debian-stable-gnutls:
+    <<: *umurmur
+    profiles: [stable]
+    build:
+      context: .
+      dockerfile: Dockerfile.debian
+      args:
+        BASE_IMAGE: debian:stable-slim
+        SSL: gnutls
+
+  debian-stable-mbedtls:
+    <<: *umurmur
+    profiles: [stable]
+    build:
+      context: .
+      dockerfile: Dockerfile.debian
+      args:
+        BASE_IMAGE: debian:stable-slim
+        SSL: mbedtls
+
+  debian-stable-openssl:
+    <<: *umurmur
+    profiles: [stable]
+    build:
+      context: .
+      dockerfile: Dockerfile.debian
+      args:
+        BASE_IMAGE: debian:stable-slim
+        SSL: openssl
+
+  alpine-latest-gnutls:
+    <<: *umurmur
+    profiles: [rolling]
+    build:
+      context: .
+      dockerfile: Dockerfile.alpine
+      args:
+        BASE_IMAGE: alpine:latest
+        SSL: gnutls
+
+  alpine-latest-mbedtls:
+    <<: *umurmur
+    profiles: [rolling]
+    build:
+      context: .
+      dockerfile: Dockerfile.alpine
+      args:
+        BASE_IMAGE: alpine:latest
+        SSL: mbedtls
+
+  alpine-latest-openssl:
+    <<: *umurmur
+    profiles: [rolling]
+    build:
+      context: .
+      dockerfile: Dockerfile.alpine
+      args:
+        BASE_IMAGE: alpine:latest
+        SSL: openssl
+
+  debian-unstable-gnutls:
+    <<: *umurmur
+    profiles: [rolling]
+    build:
+      context: .
+      dockerfile: Dockerfile.debian
+      args:
+        BASE_IMAGE: debian:unstable-slim
+        SSL: gnutls
+
+  debian-unstable-mbedtls:
+    <<: *umurmur
+    profiles: [rolling]
+    build:
+      context: .
+      dockerfile: Dockerfile.debian
+      args:
+        BASE_IMAGE: debian:unstable-slim
+        SSL: mbedtls
+
+  debian-unstable-openssl:
+    <<: *umurmur
+    profiles: [rolling]
+    build:
+      context: .
+      dockerfile: Dockerfile.debian
+      args:
+        BASE_IMAGE: debian:unstable-slim
+        SSL: openssl
 
 volumes:
   umurmur-certs:
-


### PR DESCRIPTION
- Expand compliation testing to the "unstable/rolling" distro releases, and test those nightly. 
- Use distro packages exclusively instead of compiling libraries from source.
- `cert-init` is still used until 0.5.0 that introduces certificate generation for all supported SSL libraries.

Recent builds on Alpine are expected to fail until #240 is merged.